### PR TITLE
Add MRC file I/O and optimize vector rotations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+numpy
+scipy
+pytest
+mrcfile

--- a/src/smap_tools_python/__init__.py
+++ b/src/smap_tools_python/__init__.py
@@ -1,0 +1,51 @@
+"""Python utilities for SMAP tools."""
+
+from .cos_mask import variable_cos_mask, rrj
+from .quaternion import Quaternion
+from .constants import def_consts
+from .zp import zp
+from .fov import fov_to_num, num_to_fov
+from .fft import ftj, iftj
+from .mask_central_cross import mask_central_cross
+from .mask_volume import mask_volume
+from .ks import get_ks
+from .ctf import ctf
+from .crop_pad import crop_or_pad
+from .resize_for_fft import resize_for_fft
+from .rotate import rotate3d_vector, rotate2d_matrix, rotate3d_matrix, rot90j
+from .radial import radial_mean, radial_average, radial_max
+from .g2 import g2
+from .mean import mean
+from .getcp import get_center_pixel, getcp
+from .mrc import read_mrc, write_mrc
+
+__all__ = [
+    "variable_cos_mask",
+    "rrj",
+    "Quaternion",
+    "def_consts",
+    "zp",
+    "fov_to_num",
+    "num_to_fov",
+    "ftj",
+    "iftj",
+    "mask_central_cross",
+    "mask_volume",
+    "get_ks",
+    "ctf",
+    "crop_or_pad",
+    "resize_for_fft",
+    "rotate3d_vector",
+    "rotate2d_matrix",
+    "rotate3d_matrix",
+    "rot90j",
+    "radial_mean",
+    "radial_average",
+    "radial_max",
+    "g2",
+    "mean",
+    "get_center_pixel",
+    "getcp",
+    "read_mrc",
+    "write_mrc",
+]

--- a/src/smap_tools_python/constants.py
+++ b/src/smap_tools_python/constants.py
@@ -1,0 +1,22 @@
+import numpy as np
+
+
+def def_consts():
+    """Define physical constants used by SMAP tools."""
+    consts = {
+        "V": 300e3,
+        "m_e": 9.10938215e-31,
+        "h": 6.636e-34,
+    }
+    consts["hbar"] = consts["h"] / (2 * np.pi)
+    consts["q_e"] = 1.602e-19
+    consts["wl"] = 0.00197e-9
+    consts["IC"] = (2 * consts["m_e"] / (consts["hbar"] ** 2)) * consts["q_e"]
+    consts["k"] = 2 * np.pi / consts["wl"]
+    consts["Cs"] = 2.7e-3
+    consts["Cc"] = 2.7e-3
+    consts["a_i"] = 0.05e-3
+    consts["dE"] = 0.7
+    consts["c"] = 2.99792458e8
+    consts["c_v"] = consts["c"]
+    return consts

--- a/src/smap_tools_python/cos_mask.py
+++ b/src/smap_tools_python/cos_mask.py
@@ -1,0 +1,28 @@
+import numpy as np
+
+
+def rrj(shape):
+    """Compute normalized radial coordinates for a 2D grid."""
+    dim_max = max(shape)
+    cp = dim_max // 2
+    x = np.arange(dim_max) - cp
+    X = np.broadcast_to(x, (dim_max, dim_max))
+    Y = X.T
+    R = np.sqrt(X**2 + Y**2)
+    R = R / (2 * R[cp, 0])
+    return R[: shape[0], : shape[1]]
+
+
+def variable_cos_mask(im_size, mask_edges, a_per_pix):
+    """Replicates MATLAB's variableCosMask function."""
+    mask_edge_in, mask_edge_out = mask_edges
+    nn = rrj((im_size, im_size))
+    R = nn / a_per_pix
+    Rt = R <= mask_edge_in
+    RR = np.abs(R - mask_edge_in) * (~Rt)
+    Rtt = R > mask_edge_out
+    RR[Rtt] = np.pi / 2
+    T = (mask_edge_in - mask_edge_out) * 2
+    RRR = 0.5 + 0.5 * np.cos(2 * np.pi * RR / T)
+    RRR[Rtt] = 0
+    return RRR

--- a/src/smap_tools_python/crop_pad.py
+++ b/src/smap_tools_python/crop_pad.py
@@ -1,0 +1,39 @@
+import numpy as np
+
+def crop_or_pad(arr, new_shape, pad_value=0):
+    """Center crop or pad an array to ``new_shape``.
+
+    Parameters
+    ----------
+    arr : array_like
+        Input array to be cropped or padded.
+    new_shape : tuple of int
+        Desired output shape. Must have same length as ``arr.ndim``.
+    pad_value : scalar, optional
+        Value to use for padding when ``new_shape`` exceeds ``arr`` dimensions.
+
+    Returns
+    -------
+    numpy.ndarray
+        Array cropped or padded to ``new_shape``.
+    """
+    arr = np.asarray(arr)
+    if len(new_shape) != arr.ndim:
+        raise ValueError("new_shape must match number of dimensions of arr")
+
+    slices = []
+    pads = []
+    for old, new in zip(arr.shape, new_shape):
+        if new < old:
+            start = (old - new) // 2
+            slices.append(slice(start, start + new))
+            pads.append((0, 0))
+        else:
+            slices.append(slice(0, old))
+            before = (new - old) // 2
+            after = new - old - before
+            pads.append((before, after))
+    cropped = arr[tuple(slices)]
+    if any(new > old for old, new in zip(arr.shape, new_shape)):
+        cropped = np.pad(cropped, pads, mode='constant', constant_values=pad_value)
+    return cropped

--- a/src/smap_tools_python/ctf.py
+++ b/src/smap_tools_python/ctf.py
@@ -1,0 +1,84 @@
+import numpy as np
+from .constants import def_consts
+from .ks import get_ks
+
+
+def ctf(df, edge_size, params):
+    """Generate a contrast transfer function (CTF) image.
+
+    Parameters
+    ----------
+    df : array_like, shape (n,3)
+        Defocus parameters ``(df1, df2, alpha_ast)`` in nanometers and radians.
+    edge_size : int
+        Size of the (square) output CTF image.
+    params : dict
+        Microscope parameters with keys ``Cs``, ``Cc``, ``V_acc``, ``deltaE``,
+        ``a_i`` and ``aPerPix``. Optional key ``F_abs`` specifies the amplitude
+        contrast fraction (default 0).
+
+    Returns
+    -------
+    ndarray
+        CTF image of shape ``(edge_size, edge_size)`` or ``(..., n)`` if multiple
+        defocus sets are provided.
+    """
+    df = np.atleast_2d(np.asarray(df, dtype=float))
+    n_ctf = df.shape[0]
+
+    Cs = params["Cs"]
+    Cc = params["Cc"]
+    V_acc = params["V_acc"]
+    deltaE = params["deltaE"]
+    a_i = params["a_i"]
+    pixel_size = params["aPerPix"]
+    F_abs = params.get("F_abs", 0.0)
+
+    cc = def_consts()
+    h = cc["h"]
+    e = cc["q_e"]
+    c_v = cc["c"]
+    m_e = cc["m_e"]
+    lam = h / np.sqrt(2 * m_e * e * V_acc * (1 + e * V_acc / (2 * m_e * c_v ** 2)))
+
+    edge_size = int(np.max(np.atleast_1d(edge_size)))
+    dummy = np.ones((edge_size, edge_size), dtype=np.float32)
+    k_2d, center = get_ks(dummy, pixel_size)
+
+    x = np.arange(-center, edge_size - center)
+    X, Y = np.meshgrid(x, x)
+    Y = -Y
+    alpha_g = np.arctan2(Y, X)
+    alpha_g[alpha_g < 0] += 2 * np.pi
+
+    freq = k_2d * 1e10
+    CTF = np.zeros((edge_size, edge_size, n_ctf), dtype=np.complex64)
+    for i in range(n_ctf):
+        df1, df2, alpha_ast = df[i]
+        df1 *= 1e-9
+        df2 *= 1e-9
+        ddf = df1 - df2
+        df_ast = 0.5 * (df1 + df2 + ddf * np.cos(2 * (alpha_g - alpha_ast)))
+        chi = (np.pi * lam * freq**2) * (df_ast - (Cs * (lam**2) * (freq**2) / 2))
+        w1 = F_abs
+        w2 = 1 - w1
+        ctf_temp = (w1 * np.sin(chi) - w2 * np.cos(chi)) + 1j * (
+            -w1 * np.cos(chi) - w2 * np.sin(chi)
+        )
+        term_one = -(
+            (
+                np.pi
+                * lam
+                * (freq**2)
+                * Cc
+                * deltaE
+                / (4 * V_acc * np.sqrt(np.log(2)))
+            )
+            ** 2
+        )
+        term_two = -(
+            (np.pi * Cs * (lam**2) * (freq**3) - np.pi * df_ast * freq) ** 2
+        ) * (a_i**2) / np.log(2)
+        CTF[:, :, i] = ctf_temp * np.exp(term_one) * np.exp(term_two)
+
+    return CTF.squeeze()

--- a/src/smap_tools_python/fft.py
+++ b/src/smap_tools_python/fft.py
@@ -1,0 +1,14 @@
+import numpy as np
+
+
+def ftj(inref):
+    """Forward FFT with MATLAB-like normalization."""
+    Npix = np.prod(inref.shape)
+    return np.fft.fftshift(np.fft.fftn(np.fft.ifftshift(inref))) / np.sqrt(Npix)
+
+
+def iftj(inref):
+    """Inverse FFT matching MATLAB's iftj.m."""
+    Npix = np.prod(inref.shape)
+    inref = np.nan_to_num(inref)
+    return np.fft.fftshift(np.real(np.fft.ifftn(np.fft.ifftshift(inref)))) * np.sqrt(Npix)

--- a/src/smap_tools_python/fov.py
+++ b/src/smap_tools_python/fov.py
@@ -1,0 +1,36 @@
+from datetime import datetime, timedelta
+from .zp import zp
+
+ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+
+def fov_to_num(fov_ref):
+    """Convert a field-of-view reference string to a numeric identifier."""
+    if isinstance(fov_ref, (list, tuple)):
+        fov_ref = fov_ref[0]
+    date_part, letter_part, num_part = fov_ref.split("_")
+    the_year = int("20" + date_part[4:6])
+    the_month = int(date_part[0:2])
+    the_date = int(date_part[2:4])
+    baseline = datetime(2014, 1, 1, 12, 0, 0)
+    target = datetime(the_year, the_month, the_date, 12, 0, 0)
+    days = (target - baseline).days
+    temp = list("0" * 9)
+    temp[0:4] = list(zp(days, 4))
+    idx = ALPHABET.index(letter_part.upper()) + 1
+    temp[4:6] = list(zp(idx, 2))
+    temp[6:9] = list(zp(int(num_part), 3))
+    return int("".join(temp))
+
+
+def num_to_fov(numref):
+    """Convert a numeric identifier back to a field-of-view reference string."""
+    num_str = str(int(numref)).zfill(9)
+    days = int(num_str[0:4])
+    baseline = datetime(2014, 1, 1, 12, 0, 0)
+    target = baseline + timedelta(days=days)
+    date_part = target.strftime("%m%d%y")
+    letter_idx = int(num_str[4:6])
+    letter = ALPHABET[letter_idx - 1]
+    num_part = zp(int(num_str[6:9]), 4)
+    return f"{date_part}_{letter}_{num_part}"

--- a/src/smap_tools_python/g2.py
+++ b/src/smap_tools_python/g2.py
@@ -1,0 +1,21 @@
+import numpy as np
+
+
+def g2(xyz, beta=(1.0, 0.5)):
+    """Evaluate a Gaussian ``A*exp(-xyz**2/(2*sigma**2))``.
+
+    Parameters
+    ----------
+    xyz : array_like
+        Input coordinates.
+    beta : tuple of float, optional
+        Sequence ``(A, sigma)`` giving the amplitude and standard deviation.
+
+    Returns
+    -------
+    numpy.ndarray
+        Gaussian evaluated at ``xyz`` with the given parameters.
+    """
+    xyz = np.asarray(xyz, dtype=float)
+    A, sigma = beta
+    return A * np.exp(-(xyz ** 2) / (2.0 * sigma ** 2))

--- a/src/smap_tools_python/getcp.py
+++ b/src/smap_tools_python/getcp.py
@@ -1,0 +1,23 @@
+import numpy as np
+
+
+def get_center_pixel(shape_or_array):
+    """Return the 0-based centre pixel index for each dimension.
+
+    Parameters
+    ----------
+    shape_or_array : array_like or tuple of int
+        Array or shape from which to determine the centre.
+
+    Returns
+    -------
+    tuple of int
+        Centre pixel coordinates using Python's 0-based indexing.
+    """
+    shape = getattr(shape_or_array, "shape", shape_or_array)
+    shape = np.asarray(shape, dtype=int)
+    return tuple(shape // 2)
+
+
+# MATLAB compatibility alias
+getcp = get_center_pixel

--- a/src/smap_tools_python/ks.py
+++ b/src/smap_tools_python/ks.py
@@ -1,0 +1,28 @@
+import numpy as np
+from .cos_mask import rrj
+
+
+def get_ks(imref, a_per_pix):
+    """Compute radial frequency map for an image reference.
+
+    Parameters
+    ----------
+    imref : array-like or int
+        Reference image or its size. If an integer is provided, a square array
+        of that size is assumed.
+    a_per_pix : float
+        Pixel size in Angstroms per pixel.
+
+    Returns
+    -------
+    k_2d : ndarray
+        Radial frequency at each pixel.
+    center_pixel : int
+        Index of the central pixel (0-based).
+    """
+    if np.isscalar(imref):
+        imref = np.zeros((int(imref), int(imref)), dtype=np.float32)
+    Npix = imref.shape[0]
+    center_pixel = Npix // 2
+    k_2d = rrj(imref.shape) / a_per_pix
+    return k_2d, center_pixel

--- a/src/smap_tools_python/mask_central_cross.py
+++ b/src/smap_tools_python/mask_central_cross.py
@@ -1,0 +1,21 @@
+import numpy as np
+from .fft import ftj, iftj
+
+
+def mask_central_cross(imref):
+    """Zero out the central cross in Fourier space."""
+    Npix = imref.shape[0]
+    cp = Npix // 2
+    if np.isrealobj(imref):
+        imref_F = ftj(imref)
+        ift_flag = True
+    else:
+        imref_F = imref
+        ift_flag = False
+    dc_val = np.abs(imref_F[cp, cp])
+    imref_F[cp, :] = 0
+    imref_F[:, cp] = 0
+    imref_F[cp, cp] = dc_val
+    if ift_flag:
+        return iftj(imref_F)
+    return imref_F

--- a/src/smap_tools_python/mask_volume.py
+++ b/src/smap_tools_python/mask_volume.py
@@ -1,0 +1,72 @@
+import numpy as np
+try:
+    from scipy.ndimage import distance_transform_edt
+except Exception:  # pragma: no cover - SciPy may be unavailable
+    distance_transform_edt = None
+
+
+def mask_volume(mapref, mask_params, mode="mask"):
+    """Mask a 3-D volume using raised cosine or shell modes.
+
+    Parameters
+    ----------
+    mapref : array_like
+        Input volume.
+    mask_params : sequence
+        Parameters controlling the mask. For ``mode='mask'`` these are
+        ``(near_edge, cos_width)``. For ``mode='shell'`` they are
+        ``(d_shell, t_shell)``.
+    mode : {'mask', 'shell'}, optional
+        Masking strategy. ``'mask'`` creates a raised cosine mask from the
+        volume edges inward. ``'shell'`` creates a thin shell around the
+        boundary of detected features.
+
+    Returns
+    -------
+    tuple of numpy.ndarray
+        ``(out, mask, D)`` where ``out`` is the masked volume, ``mask`` the
+        mask itself, and ``D`` the distance transform used.
+    """
+    if distance_transform_edt is None:
+        raise ImportError("scipy is required for mask_volume")
+
+    mapref = np.asarray(mapref, dtype=float)
+    mask_params = np.asarray(mask_params, dtype=float)
+
+    bg_val = np.bincount(mapref.astype(int).ravel()).argmax()
+    mm = mapref - bg_val
+    thr = np.std(np.abs(mm))
+    BW = np.abs(mm) > thr
+
+    if mode == "mask":
+        D = distance_transform_edt(~BW)
+        near_edge, cos_width = mask_params
+        far_edge = near_edge + cos_width
+        D11 = D.copy()
+        D11[D <= near_edge] = 0
+        D11[D >= far_edge] = np.pi
+        between = (D > near_edge) & (D < far_edge)
+        temp = (D[between] - near_edge) * (np.pi / cos_width)
+        D11[between] = temp
+        mask = np.cos(D11) / 2 + 0.5
+    elif mode == "shell":
+        # preliminary cosine mask to dilate tight spaces
+        D0 = distance_transform_edt(~BW)
+        D11 = D0.copy()
+        D11[D0 <= 0] = 0
+        D11[D0 >= 1] = np.pi
+        between = (D0 > 0) & (D0 < 1)
+        D11[between] = D0[between] * np.pi
+        BW = (np.cos(D11) / 2 + 0.5) > 0
+
+        D = distance_transform_edt(~BW)
+        d_shell, t_shell = mask_params
+        D11 = np.abs(D - d_shell)
+        D11[D == 0] = np.nan
+        D11[D11 > t_shell] = np.nan
+        mask = np.where(np.isnan(D11), 0, 1)
+    else:
+        raise ValueError("mode must be 'mask' or 'shell'")
+
+    outref = mm * mask + bg_val
+    return outref, mask, D

--- a/src/smap_tools_python/mean.py
+++ b/src/smap_tools_python/mean.py
@@ -1,0 +1,24 @@
+import numpy as np
+
+
+def mean(arr, axis=0):
+    """NaN-aware mean along a given axis.
+
+    This mirrors MATLAB's ``smap.mean`` helper, which averages while ignoring
+    ``NaN`` values. The default axis follows MATLAB conventions, averaging
+    along the first dimension (across rows).
+
+    Parameters
+    ----------
+    arr : array_like
+        Input array.
+    axis : int, optional
+        Axis along which to compute the mean. Defaults to ``0``.
+
+    Returns
+    -------
+    numpy.ndarray or scalar
+        The mean values with ``NaN`` entries skipped.
+    """
+    arr = np.asarray(arr)
+    return np.nanmean(arr, axis=axis)

--- a/src/smap_tools_python/mrc.py
+++ b/src/smap_tools_python/mrc.py
@@ -1,0 +1,61 @@
+"""Minimal MRC file I/O helpers using the mrcfile library."""
+
+from __future__ import annotations
+
+import numpy as np
+
+try:  # pragma: no cover - mrcfile may be missing
+    import mrcfile
+except Exception:  # pragma: no cover
+    mrcfile = None
+
+
+def read_mrc(path: str):
+    """Read an MRC file and return the data array and voxel size.
+
+    Parameters
+    ----------
+    path : str
+        Path to the MRC file on disk.
+
+    Returns
+    -------
+    tuple
+        ``(data, voxel_size)`` where ``data`` is a ``numpy.ndarray`` and
+        ``voxel_size`` is a 3-tuple giving the voxel spacing in angstroms.
+    """
+
+    if mrcfile is None:  # pragma: no cover
+        raise ImportError("mrcfile is required to read MRC files")
+
+    with mrcfile.open(path, permissive=True) as mrc:
+        data = np.array(mrc.data, copy=True)
+        voxel = tuple(float(v) for v in mrc.voxel_size)
+    return data, voxel
+
+
+def write_mrc(path: str, data, voxel_size=1.0, overwrite=True):
+    """Write ``data`` to ``path`` as an MRC file.
+
+    Parameters
+    ----------
+    path : str
+        Output filename.
+    data : array_like
+        Array of data to store. It will be converted to ``float32``.
+    voxel_size : float or sequence of float, optional
+        Voxel size in angstroms. A scalar applies to all axes.
+    overwrite : bool, optional
+        Whether to overwrite an existing file.
+    """
+
+    if mrcfile is None:  # pragma: no cover
+        raise ImportError("mrcfile is required to write MRC files")
+
+    arr = np.asarray(data, dtype=np.float32)
+    with mrcfile.new(path, overwrite=overwrite) as mrc:
+        mrc.set_data(arr)
+        if np.isscalar(voxel_size):
+            mrc.voxel_size = tuple([float(voxel_size)] * 3)
+        else:
+            mrc.voxel_size = tuple(float(v) for v in voxel_size)

--- a/src/smap_tools_python/quaternion.py
+++ b/src/smap_tools_python/quaternion.py
@@ -1,0 +1,65 @@
+import numpy as np
+
+
+class Quaternion:
+    """Minimal quaternion class mirroring MATLAB's quaternion behavior."""
+
+    def __init__(self, w=0.0, x=0.0, y=0.0, z=0.0):
+        self.q = np.array([w, x, y, z], dtype=float)
+
+    @classmethod
+    def from_vector(cls, vec):
+        """Create a quaternion with zero scalar part from a 3-vector."""
+        v = np.asarray(vec, dtype=float)
+        return cls(0.0, *v)
+
+    @classmethod
+    def from_axis_angle(cls, axis, angle):
+        """Construct a unit quaternion from rotation axis and angle."""
+        axis = np.asarray(axis, dtype=float)
+        axis = axis / np.linalg.norm(axis)
+        half = angle / 2.0
+        w = np.cos(half)
+        xyz = axis * np.sin(half)
+        return cls(w, *xyz)
+
+    def conjugate(self):
+        """Return the quaternion conjugate."""
+        w, x, y, z = self.q
+        return Quaternion(w, -x, -y, -z)
+
+    def normalize(self):
+        """Return a normalized quaternion."""
+        n = np.linalg.norm(self.q)
+        if n == 0:
+            return Quaternion()
+        return Quaternion(*(self.q / n))
+
+    def to_rotation_matrix(self):
+        """Convert the quaternion to a 3x3 rotation matrix."""
+        w, x, y, z = self.normalize().q
+        return np.array([
+            [1 - 2 * (y**2 + z**2), 2 * (x * y - z * w), 2 * (x * z + y * w)],
+            [2 * (x * y + z * w), 1 - 2 * (x**2 + z**2), 2 * (y * z - x * w)],
+            [2 * (x * z - y * w), 2 * (y * z + x * w), 1 - 2 * (x**2 + y**2)],
+        ])
+
+    def rotate_vector(self, vec):
+        """Rotate a 3-vector using the quaternion."""
+        vq = Quaternion.from_vector(vec)
+        rq = self * vq * self.conjugate()
+        return rq.q[1:]
+
+    def __mul__(self, other):
+        w1, x1, y1, z1 = self.q
+        w2, x2, y2, z2 = other.q
+        return Quaternion(
+            w1 * w2 - x1 * x2 - y1 * y2 - z1 * z2,
+            w1 * x2 + x1 * w2 + y1 * z2 - z1 * y2,
+            w1 * y2 - x1 * z2 + y1 * w2 + z1 * x2,
+            w1 * z2 + x1 * y2 - y1 * x2 + z1 * w2,
+        )
+
+    def __repr__(self):
+        w, x, y, z = self.q
+        return f"Quaternion({w}, {x}, {y}, {z})"

--- a/src/smap_tools_python/radial.py
+++ b/src/smap_tools_python/radial.py
@@ -1,0 +1,56 @@
+import numpy as np
+
+
+def radial_mean(image: np.ndarray) -> np.ndarray:
+    """Compute mean value for each integer radius from image center.
+
+    Parameters
+    ----------
+    image : ndarray
+        2-D array representing the image.
+
+    Returns
+    -------
+    profile : ndarray
+        1-D array where ``profile[r]`` is the mean of all pixels whose
+        rounded radius equals ``r``.
+    """
+    y, x = np.indices(image.shape)
+    cy = (image.shape[0] - 1) / 2.0
+    cx = (image.shape[1] - 1) / 2.0
+    r = np.sqrt((x - cx) ** 2 + (y - cy) ** 2).astype(np.int64)
+
+    r_flat = r.ravel()
+    img_flat = image.ravel()
+
+    sums = np.bincount(r_flat, weights=img_flat)
+    counts = np.bincount(r_flat)
+    counts[counts == 0] = 1
+    return sums / counts
+
+
+def radial_average(image: np.ndarray) -> np.ndarray:
+    """Replace each pixel with the mean of its radius."""
+    profile = radial_mean(image)
+    y, x = np.indices(image.shape)
+    cy = (image.shape[0] - 1) / 2.0
+    cx = (image.shape[1] - 1) / 2.0
+    r = np.sqrt((x - cx) ** 2 + (y - cy) ** 2).astype(np.int64)
+    return profile[r]
+
+
+def radial_max(image: np.ndarray) -> np.ndarray:
+    """Compute maximum value for each integer radius from image center."""
+    y, x = np.indices(image.shape)
+    cy = (image.shape[0] - 1) / 2.0
+    cx = (image.shape[1] - 1) / 2.0
+    r = np.sqrt((x - cx) ** 2 + (y - cy) ** 2).astype(np.int64)
+
+    r_flat = r.ravel()
+    img_flat = image.ravel()
+    max_r = r_flat.max() + 1
+    out = np.full(max_r, -np.inf)
+    for rad, val in zip(r_flat, img_flat):
+        if val > out[rad]:
+            out[rad] = val
+    return out

--- a/src/smap_tools_python/resize_for_fft.py
+++ b/src/smap_tools_python/resize_for_fft.py
@@ -1,0 +1,44 @@
+import numpy as np
+from .crop_pad import crop_or_pad
+
+def _has_large_prime_factor(n):
+    for p in (2, 3):
+        while n % p == 0 and n > 1:
+            n //= p
+    return n != 1
+
+def _adjust_dim(dim, inc):
+    while _has_large_prime_factor(dim):
+        dim += inc
+    return dim
+
+def resize_for_fft(arr, mode='crop', pad_value=0):
+    """Resize array to FFT-friendly dimensions.
+
+    Dimensions are adjusted so their prime factors are only 2 or 3. The final
+    array is cubic with the largest adjusted dimension and is centered using
+    :func:`crop_or_pad`.
+
+    Parameters
+    ----------
+    arr : array_like
+        Input array.
+    mode : {'crop', 'pad'}, optional
+        Whether to crop down or pad up to reach an FFT size.
+    pad_value : scalar, optional
+        Value to use when padding; ignored in ``crop`` mode.
+
+    Returns
+    -------
+    numpy.ndarray
+        Resized array suitable for efficient FFT computation.
+    """
+    arr = np.asarray(arr)
+    inc = -1 if mode == 'crop' else 1
+    dims_new = [_adjust_dim(d, inc) for d in arr.shape]
+    new_dim = max(dims_new)
+    dims_new = [new_dim] * arr.ndim
+    mean_val = np.nanmean(arr)
+    shifted = arr - mean_val
+    result = crop_or_pad(shifted, dims_new, pad_value if mode == 'pad' else 0)
+    return result + mean_val

--- a/src/smap_tools_python/rotate.py
+++ b/src/smap_tools_python/rotate.py
@@ -1,0 +1,160 @@
+import numpy as np
+
+
+def rotate3d_vector(R, v):
+    """Rotate 3‑D vectors using a rotation matrix with NumPy broadcasting.
+
+    The function accepts a single vector or an array of vectors.  If the first
+    dimension has length 3 the vectors are interpreted as column vectors
+    (``(3, N)``).  Otherwise the last dimension is assumed to hold the vector
+    components (``(N, 3)`` or ``(..., 3)``) and broadcasting is used to apply
+    the rotation in a batched fashion.
+
+    Parameters
+    ----------
+    R : array_like, shape (3, 3)
+        Rotation matrix.
+    v : array_like
+        Vector or array of vectors to rotate.
+
+    Returns
+    -------
+    numpy.ndarray
+        Rotated vector(s) with the same orientation as the input.
+    """
+
+    R = np.asarray(R)
+    v = np.asarray(v)
+    if v.ndim == 1:
+        return R @ v
+    if v.shape[0] == 3 and v.ndim == 2:
+        return R @ v
+    return np.einsum("ij,...j->...i", R, v)
+
+
+def rot90j(arr, k=0):
+    """Rotate an array by 90° increments while keeping its center aligned.
+
+    This mirrors the MATLAB ``rot90j`` helper, applying the same pixel shifts
+    for even-sized arrays so that the central pixel remains in place after
+    rotation.
+
+    Parameters
+    ----------
+    arr : array_like
+        2-D array to rotate.
+    k : int, optional
+        Number of 90° rotations. Positive values rotate counter-clockwise.
+
+    Returns
+    -------
+    numpy.ndarray
+        Rotated array.
+    """
+
+    k = int(k) % 4
+    if k == 0:
+        return np.array(arr, copy=True)
+
+    out = np.rot90(arr, k)
+    edge = out.shape[0]
+    if edge % 2 == 0:
+        if k == 1:
+            shifts = (1, 0)
+        elif k == 2:
+            shifts = (1, 1)
+        elif k == 3:
+            shifts = (0, 1)
+        else:
+            shifts = (0, 0)
+        out = np.roll(out, shifts, axis=(0, 1))
+    return out
+
+
+def rotate2d_matrix(image, R):
+    """Rotate a 2-D array using a rotation matrix.
+
+    The implementation performs nearest-neighbour interpolation purely with
+    NumPy so that it has no heavy dependencies.  It is therefore limited to
+    moderate rotations but suffices to mirror the basic behaviour of the
+    original MATLAB ``rotate2dMatrix`` utility.
+
+    Parameters
+    ----------
+    image : array_like, shape (M, N)
+        2-D image to rotate.
+    R : array_like, shape (2, 2) or (3, 3)
+        Rotation matrix. If a 3×3 matrix is supplied, the upper-left 2×2 block
+        is used.
+
+    Returns
+    -------
+    numpy.ndarray
+        Rotated image with the same shape as the input.
+    """
+
+    image = np.asarray(image)
+    R = np.asarray(R, dtype=float)
+    if R.shape == (3, 3):
+        R = R[:2, :2]
+    n = np.array(image.shape)
+    center = (n - 1) / 2.0
+    # coordinates of output pixels
+    grid = np.indices(n).reshape(2, -1)
+    coords = grid.T - center
+    coords = coords @ R.T + center
+    coords = np.rint(coords).astype(int)
+    mask = (
+        (coords[:, 0] >= 0)
+        & (coords[:, 0] < n[0])
+        & (coords[:, 1] >= 0)
+        & (coords[:, 1] < n[1])
+    )
+    out = np.zeros_like(image)
+    out[grid[0, mask], grid[1, mask]] = image[coords[mask, 0], coords[mask, 1]]
+    return out
+
+
+def rotate3d_matrix(volume, R):
+    """Rotate a 3-D volume using a rotation matrix.
+
+    As with :func:`rotate2d_matrix`, nearest-neighbour interpolation is used to
+    avoid external dependencies.  The function preserves the input shape and
+    fills voxels falling outside the rotated volume with zeros.
+
+    Parameters
+    ----------
+    volume : array_like, shape (X, Y, Z)
+        3-D volume to rotate.
+    R : array_like, shape (3, 3)
+        Rotation matrix.
+
+    Returns
+    -------
+    numpy.ndarray
+        Rotated volume with the same shape as the input.
+    """
+
+    volume = np.asarray(volume)
+    R = np.asarray(R, dtype=float)
+    n = np.array(volume.shape)
+    center = (n - 1) / 2.0
+    grid = np.indices(n).reshape(3, -1)
+    coords = grid.T - center
+    coords = coords @ R.T + center
+    coords = np.rint(coords).astype(int)
+    mask = (
+        (coords[:, 0] >= 0)
+        & (coords[:, 0] < n[0])
+        & (coords[:, 1] >= 0)
+        & (coords[:, 1] < n[1])
+        & (coords[:, 2] >= 0)
+        & (coords[:, 2] < n[2])
+    )
+    out = np.zeros_like(volume)
+    out[
+        grid[0, mask],
+        grid[1, mask],
+        grid[2, mask],
+    ] = volume[coords[mask, 0], coords[mask, 1], coords[mask, 2]]
+    return out

--- a/src/smap_tools_python/zp.py
+++ b/src/smap_tools_python/zp.py
@@ -1,0 +1,4 @@
+def zp(num_in, N, pad_char="0"):
+    """Zero-pad a number or string to a given width."""
+    s = str(num_in)
+    return s.rjust(N, pad_char)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,3 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))

--- a/tests/test_crop_resize.py
+++ b/tests/test_crop_resize.py
@@ -1,0 +1,25 @@
+import numpy as np
+from smap_tools_python import crop_or_pad, resize_for_fft
+
+def test_crop_or_pad_crop():
+    arr = np.arange(16).reshape(4, 4)
+    out = crop_or_pad(arr, (2, 2))
+    expected = np.array([[5, 6], [9, 10]])
+    assert np.array_equal(out, expected)
+
+def test_crop_or_pad_pad():
+    arr = np.array([[1, 2], [3, 4]])
+    out = crop_or_pad(arr, (4, 4), pad_value=1)
+    expected = np.array([[1, 1, 1, 1],
+                         [1, 1, 2, 1],
+                         [1, 3, 4, 1],
+                         [1, 1, 1, 1]])
+    assert np.array_equal(out, expected)
+
+def test_resize_for_fft_pad_and_crop():
+    arr_pad = np.zeros((5, 5))
+    out_pad = resize_for_fft(arr_pad, mode='pad')
+    assert out_pad.shape == (6, 6)
+    arr_crop = np.zeros((7, 7))
+    out_crop = resize_for_fft(arr_crop, mode='crop')
+    assert out_crop.shape == (6, 6)

--- a/tests/test_ctf.py
+++ b/tests/test_ctf.py
@@ -1,0 +1,20 @@
+import numpy as np
+from smap_tools_python import ctf
+
+
+def test_ctf_zero_defocus():
+    params = {
+        "Cs": 0.0,
+        "Cc": 0.0,
+        "V_acc": 300e3,
+        "deltaE": 0.0,
+        "a_i": 0.0,
+        "aPerPix": 1.0,
+        "F_abs": 0.0,
+    }
+    out = ctf(np.array([[0.0, 0.0, 0.0]]), 4, params)
+    assert out.shape == (4, 4)
+    center = out.shape[0] // 2
+    val = out[center, center]
+    assert np.isclose(val.real, -1.0)
+    assert np.isclose(val.imag, 0.0)

--- a/tests/test_fft.py
+++ b/tests/test_fft.py
@@ -1,0 +1,8 @@
+import numpy as np
+from src.smap_tools_python import ftj, iftj
+
+
+def test_fft_roundtrip():
+    arr = np.random.rand(4, 4)
+    rec = iftj(ftj(arr))
+    assert np.allclose(arr, rec, atol=1e-6)

--- a/tests/test_fov.py
+++ b/tests/test_fov.py
@@ -1,0 +1,6 @@
+from smap_tools_python import fov_to_num, num_to_fov
+
+
+def test_fov_roundtrip():
+    ref = "030518_A_0123"
+    assert num_to_fov(fov_to_num(ref)) == ref

--- a/tests/test_gaussian.py
+++ b/tests/test_gaussian.py
@@ -1,0 +1,15 @@
+import numpy as np
+from smap_tools_python import g2
+
+
+def test_g2_scalar():
+    assert np.isclose(g2(0.0), 1.0)
+    val = g2(1.0, (2.0, 1.0))
+    assert np.isclose(val, 2.0 * np.exp(-0.5))
+
+
+def test_g2_array():
+    x = np.array([-1.0, 0.0, 1.0])
+    res = g2(x, (1.0, 1.0))
+    expected = np.exp(-x**2 / 2.0)
+    assert np.allclose(res, expected)

--- a/tests/test_getcp.py
+++ b/tests/test_getcp.py
@@ -1,0 +1,11 @@
+import numpy as np
+from smap_tools_python import get_center_pixel, getcp
+
+
+def test_get_center_pixel_from_array():
+    arr = np.zeros((5, 7, 9))
+    assert get_center_pixel(arr) == (2, 3, 4)
+
+
+def test_getcp_from_shape_tuple():
+    assert getcp((6, 6)) == (3, 3)

--- a/tests/test_mask.py
+++ b/tests/test_mask.py
@@ -1,0 +1,28 @@
+import numpy as np
+from src.smap_tools_python import mask_central_cross
+from src.smap_tools_python import mask_volume
+
+
+def test_mask_central_cross_frequency():
+    F = np.ones((5, 5), dtype=complex)
+    out = mask_central_cross(F)
+    cp = 5 // 2
+    assert out[cp, cp] == 1
+    assert np.all(out[cp, :cp] == 0) and np.all(out[cp, cp+1:] == 0)
+    assert np.all(out[:cp, cp] == 0) and np.all(out[cp+1:, cp] == 0)
+
+
+def test_mask_volume_mask_mode():
+    vol = np.zeros((5, 5, 5), float)
+    vol[2, 2, 2] = 1
+    out, mask, D = mask_volume(vol, (1, 1))
+    assert out.shape == (5, 5, 5)
+    assert mask.shape == (5, 5, 5)
+    assert D.shape == (5, 5, 5)
+
+
+def test_mask_volume_shell_mode():
+    vol = np.zeros((5, 5, 5), float)
+    vol[2, 2, 2] = 1
+    out, mask, D = mask_volume(vol, (1, 1), mode="shell")
+    assert mask.sum() > 0

--- a/tests/test_mean.py
+++ b/tests/test_mean.py
@@ -1,0 +1,8 @@
+import numpy as np
+from smap_tools_python import mean
+
+
+def test_mean_nan_ignored():
+    arr = np.array([[1.0, np.nan], [3.0, 4.0]])
+    np.testing.assert_allclose(mean(arr), [2.0, 4.0])
+    np.testing.assert_allclose(mean(arr, axis=1), [1.0, 3.5])

--- a/tests/test_mrc.py
+++ b/tests/test_mrc.py
@@ -1,0 +1,15 @@
+import numpy as np
+import pytest
+
+from smap_tools_python import read_mrc, write_mrc
+
+pytest.importorskip("mrcfile")
+
+
+def test_mrc_roundtrip(tmp_path):
+    arr = np.random.rand(4, 4).astype(np.float32)
+    path = tmp_path / "t.mrc"
+    write_mrc(path, arr, voxel_size=1.5)
+    out, vox = read_mrc(path)
+    assert np.allclose(out, arr)
+    assert np.allclose(vox, (1.5, 1.5, 1.5))

--- a/tests/test_radial.py
+++ b/tests/test_radial.py
@@ -1,0 +1,22 @@
+import numpy as np
+from smap_tools_python.radial import radial_mean, radial_average, radial_max
+
+
+def test_radial_mean_and_average():
+    im = np.zeros((5, 5), float)
+    y, x = np.indices(im.shape)
+    r = np.round(np.sqrt((x - 2) ** 2 + (y - 2) ** 2)).astype(int)
+    im = r.astype(float)
+    prof = radial_mean(im)
+    assert np.allclose(prof[: r.max() + 1], np.arange(r.max() + 1))
+    avg = radial_average(im)
+    assert np.allclose(avg, im)
+
+
+def test_radial_max():
+    im = np.zeros((7, 7))
+    im[3, 3] = 1
+    im[3, 5] = 2  # radius ~2
+    m = radial_max(im)
+    assert m[0] == 1
+    assert m[2] == 2

--- a/tests/test_rotate.py
+++ b/tests/test_rotate.py
@@ -1,0 +1,68 @@
+import numpy as np
+from smap_tools_python import (
+    rotate3d_vector,
+    rotate2d_matrix,
+    rotate3d_matrix,
+    rot90j,
+)
+
+def test_rotate3d_vector_single():
+    R = np.array([[0, -1, 0], [1, 0, 0], [0, 0, 1]])
+    v = np.array([1, 0, 0])
+    out = rotate3d_vector(R, v)
+    assert np.allclose(out, [0, 1, 0])
+
+def test_rotate3d_vector_batch():
+    R = np.eye(3)
+    v = np.array([[1, 2, 3], [4, 5, 6]])
+    out = rotate3d_vector(R, v)
+    assert np.allclose(out, v)
+
+
+def test_rotate3d_vector_column():
+    R = np.array([[0, -1, 0], [1, 0, 0], [0, 0, 1]])
+    v = np.array([[1, 0], [0, 1], [0, 0]])
+    out = rotate3d_vector(R, v)
+    expected = R @ v
+    assert np.allclose(out, expected)
+
+
+def test_rot90j_matches_numpy():
+    arr = np.arange(9).reshape(3, 3)
+    assert np.array_equal(rot90j(arr, 1), np.rot90(arr, 1))
+
+
+def test_rot90j_even_shift():
+    arr = np.arange(16).reshape(4, 4)
+    out = rot90j(arr, 1)
+    expected = np.roll(np.rot90(arr, 1), (1, 0), axis=(0, 1))
+    assert np.array_equal(out, expected)
+
+
+def test_rotate2d_matrix_identity():
+    img = np.arange(9).reshape(3, 3)
+    R = np.eye(2)
+    assert np.array_equal(rotate2d_matrix(img, R), img)
+
+
+def test_rotate2d_matrix_90():
+    img = np.arange(9).reshape(3, 3)
+    R = np.array([[0, -1], [1, 0]])
+    out = rotate2d_matrix(img, R)
+    assert np.array_equal(out, rot90j(img, 1))
+
+
+def test_rotate3d_matrix_identity():
+    vol = np.arange(27).reshape(3, 3, 3)
+    R = np.eye(3)
+    assert np.array_equal(rotate3d_matrix(vol, R), vol)
+
+
+def test_rotate3d_matrix_z90():
+    vol = np.zeros((3, 3, 3))
+    vol[1, 0, 1] = 1
+    R = np.array([[0, -1, 0], [1, 0, 0], [0, 0, 1]])
+    out = rotate3d_matrix(vol, R)
+    expected = np.zeros_like(vol)
+    expected[1, 1, 1] = 1
+    assert np.array_equal(out, expected)


### PR DESCRIPTION
## Summary
- provide `read_mrc` and `write_mrc` helpers using the `mrcfile` library
- simplify `rotate3d_vector` via NumPy broadcasting and cover column-vector cases
- expose new utilities and add basic round-trip tests

## Testing
- `python -m py_compile $(git ls-files 'src/smap_tools_python/*.py')`
- `python -m pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement numpy (Proxy 403))*
- `pytest` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_b_68bc5ab4af808328ac8d281f77df8b60