### PR TITLE
Translate assignJobs from MATLAB

### DIFF
--- a/src/smap_tools_python/__init__.py
+++ b/src/smap_tools_python/__init__.py
@@ -35,6 +35,7 @@ from .q2r import q2r
 from .approx_mtf import approx_mtf
 from .dat_io import write_dat, read_dat_file
 from .rotations_io import write_rotations_file, read_rotations_file
+from .assign_jobs import assign_jobs
 
 __all__ = [
     "variable_cos_mask",
@@ -77,6 +78,7 @@ __all__ = [
     "apply_filter",
     "q2r",
     "approx_mtf",
+    "assign_jobs",
     "write_dat",
     "read_dat_file",
     "write_rotations_file",

--- a/src/smap_tools_python/assign_jobs.py
+++ b/src/smap_tools_python/assign_jobs.py
@@ -1,0 +1,35 @@
+import numpy as np
+
+
+def assign_jobs(n_indices, n_servers, server_id):
+    """Return the 1-based indices assigned to a server.
+
+    Parameters
+    ----------
+    n_indices : int
+        Total number of available indices.
+    n_servers : int
+        Number of servers sharing the work.
+    server_id : int
+        1-based identifier of the server requesting its slice.
+
+    Returns
+    -------
+    numpy.ndarray
+        1-based indices allocated to the requested server.  The array is
+        empty if ``server_id`` maps to no work.
+    """
+    if n_servers < 1:
+        raise ValueError("n_servers must be positive")
+    if server_id < 1 or server_id > n_servers:
+        raise ValueError("server_id must be between 1 and n_servers inclusive")
+
+    base_jobs = int(np.ceil(n_indices / n_servers))
+    jobs_per_server = np.full(n_servers, base_jobs, dtype=int)
+    jobs_with_base = np.cumsum(jobs_per_server)
+    start_inds = jobs_with_base - base_jobs + 1
+    jobs_with_base[-1] = min(jobs_with_base[-1], n_indices)
+    if server_id - 1 >= len(start_inds):
+        return np.array([], dtype=int)
+    inds = np.arange(start_inds[server_id - 1], jobs_with_base[server_id - 1] + 1)
+    return inds[inds <= n_indices]

--- a/tests/test_assign_jobs.py
+++ b/tests/test_assign_jobs.py
@@ -1,0 +1,20 @@
+import numpy as np
+from smap_tools_python import assign_jobs
+
+
+def test_assign_jobs_even_split():
+    assert np.array_equal(assign_jobs(10, 2, 1), np.arange(1, 6))
+    assert np.array_equal(assign_jobs(10, 2, 2), np.arange(6, 11))
+
+
+def test_assign_jobs_with_remainder():
+    a = assign_jobs(10, 3, 1)
+    b = assign_jobs(10, 3, 2)
+    c = assign_jobs(10, 3, 3)
+    assert np.array_equal(a, np.arange(1, 5))
+    assert np.array_equal(b, np.arange(5, 9))
+    assert np.array_equal(c, np.arange(9, 11))
+
+
+def test_assign_jobs_extra_servers():
+    assert assign_jobs(3, 5, 4).size == 0


### PR DESCRIPTION
## Summary
- expose new assign_jobs utility to evenly distribute work across workers
- include unit tests verifying even splits and handling of extra servers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68bce5cfc64c8328bd22430b16b3a6c1