### PR TITLE
Add image reading utilities

### DIFF
--- a/src/smap_tools_python/__init__.py
+++ b/src/smap_tools_python/__init__.py
@@ -26,6 +26,7 @@ from .mean import mean
 from .nm import nm
 from .getcp import get_center_pixel, getcp
 from .mrc import read_mrc, write_mrc
+from .ri import tr, ri
 from .bindata import bindata
 from .particle_diameter import particle_diameter
 from .whoami import whoami
@@ -78,6 +79,8 @@ __all__ = [
     "getcp",
     "read_mrc",
     "write_mrc",
+    "tr",
+    "ri",
     "bindata",
     "particle_diameter",
     "whoami",

--- a/src/smap_tools_python/ri.py
+++ b/src/smap_tools_python/ri.py
@@ -1,0 +1,73 @@
+"""Image reading utilities translating MATLAB's ``ri`` and ``tr`` helpers."""
+from __future__ import annotations
+
+from pathlib import Path
+import numpy as np
+
+from .mrc import read_mrc
+
+try:  # pragma: no cover - optional dependency
+    import tifffile
+except Exception:  # pragma: no cover
+    tifffile = None
+
+
+def tr(filename: str | Path):
+    """Read a TIFF file returning an array shaped ``(H, W, N)``.
+
+    Parameters
+    ----------
+    filename : str or pathlib.Path
+        Path to the TIFF file.  If no extension is provided ``.tif`` is
+        appended automatically.
+
+    Returns
+    -------
+    numpy.ndarray
+        Image data with the frame axis last, matching the MATLAB ``tr``
+        helper.  Single-frame images retain a third axis of length one.
+    """
+
+    if tifffile is None:  # pragma: no cover
+        raise ImportError("tifffile is required to read TIFF files")
+
+    path = Path(filename)
+    if path.suffix == "":
+        path = path.with_suffix(".tif")
+
+    arr = tifffile.imread(str(path))
+    if arr.ndim == 2:
+        arr = arr[..., np.newaxis]
+    else:
+        arr = np.moveaxis(arr, 0, -1)
+    return arr
+
+
+def ri(filename: str | Path):
+    """Read an image or volume in TIFF or MRC format.
+
+    Parameters
+    ----------
+    filename : str or pathlib.Path
+        Input file path.
+
+    Returns
+    -------
+    tuple
+        ``(data, info)`` where ``info`` is a dictionary that may contain
+        ``"voxel_size"`` for MRC files.  For TIFF files the dictionary is
+        empty.
+    """
+
+    path = Path(filename)
+    ext = path.suffix.lower()
+
+    if ext in (".tif", ".tiff", ""):
+        data = tr(path)
+        return data, {}
+    if ext == ".mrc":
+        data, voxel = read_mrc(str(path))
+        return data, {"voxel_size": voxel}
+    if ext == ".dm4":  # pragma: no cover - not yet implemented
+        raise NotImplementedError("DM4 reading not implemented")
+    raise ValueError(f"Unknown file type: {ext}")

--- a/tests/test_ri.py
+++ b/tests/test_ri.py
@@ -1,0 +1,37 @@
+import numpy as np
+import pytest
+
+mrcfile = pytest.importorskip("mrcfile")
+from smap_tools_python import tr, ri
+
+
+def test_tr_reads_multiframe_tiff(tmp_path):
+    tifffile = pytest.importorskip("tifffile")
+    data = np.arange(12, dtype=np.uint8).reshape(3, 4, 1)
+    data = np.concatenate([data, data + 1], axis=2)
+    path = tmp_path / "test.tif"
+    tifffile.imwrite(str(path), np.moveaxis(data, -1, 0))
+    out = tr(path)
+    assert out.shape == data.shape
+    assert np.all(out == data)
+
+
+def test_ri_handles_mrc(tmp_path):
+    arr = np.arange(8, dtype=np.float32).reshape(2, 2, 2)
+    mrc_path = tmp_path / "vol.mrc"
+    with mrcfile.new(mrc_path, overwrite=True) as mrc:
+        mrc.set_data(arr)
+        mrc.voxel_size = (1.5, 1.5, 1.5)
+    data, info = ri(mrc_path)
+    assert np.allclose(data, arr)
+    assert info["voxel_size"] == (1.5, 1.5, 1.5)
+
+
+def test_ri_handles_tiff(tmp_path):
+    tifffile = pytest.importorskip("tifffile")
+    arr = np.arange(6, dtype=np.uint8).reshape(3, 2)
+    path = tmp_path / "im.tif"
+    tifffile.imwrite(str(path), arr)
+    data, info = ri(path)
+    assert data.shape == (3, 2, 1)
+    assert info == {}


### PR DESCRIPTION
## Summary
- translate MATLAB's `tr` and `ri` helpers to Python
- expose `tr` and `ri` through package API
- test image reading for TIFF and MRC formats

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68bd7b349fec8328b35da0a5495b4346