### PR TITLE
Add CIF and PDB structure readers

### DIFF
--- a/src/smap_tools_python/__init__.py
+++ b/src/smap_tools_python/__init__.py
@@ -26,6 +26,7 @@ from .mean import mean
 from .nm import nm
 from .getcp import get_center_pixel, getcp
 from .mrc import read_mrc, write_mrc
+from .ri import tr, ri
 from .bindata import bindata
 from .particle_diameter import particle_diameter
 from .whoami import whoami
@@ -43,6 +44,8 @@ from .estimate_snr import estimate_snr
 from .ts import ts
 from .measure_qd import measure_qd
 from .mw import mw
+from .cif import read_cif_file
+from .pdb import read_pdb_file
 
 __all__ = [
     "variable_cos_mask",
@@ -78,6 +81,8 @@ __all__ = [
     "getcp",
     "read_mrc",
     "write_mrc",
+    "tr",
+    "ri",
     "bindata",
     "particle_diameter",
     "whoami",
@@ -91,6 +96,8 @@ __all__ = [
     "ts",
     "measure_qd",
     "mw",
+    "read_cif_file",
+    "read_pdb_file",
     "write_dat",
     "read_dat_file",
     "write_rotations_file",

--- a/src/smap_tools_python/cif.py
+++ b/src/smap_tools_python/cif.py
@@ -1,0 +1,60 @@
+import numpy as np
+from typing import Sequence, Tuple, List, Optional
+
+
+def read_cif_file(filename: str, chains: Optional[Sequence[str]] = None) -> Tuple[np.ndarray, np.ndarray, List[str], np.ndarray, List[str]]:
+    """Parse a minimal subset of a ``.cif`` file.
+
+    Parameters
+    ----------
+    filename:
+        Path to a CIF file.
+    chains:
+        Optional iterable of chain identifiers to keep.  All chains are
+        returned when ``None``.
+
+    Returns
+    -------
+    xyz, atom_nums, atom_list, b_factor, chain_ids
+        ``xyz`` is a 3×N array of coordinates in Å and the other outputs are
+        per-atom properties mirroring the MATLAB ``read_cif_file`` helper.
+    """
+    atom_nums: List[int] = []
+    atom_list: List[str] = []
+    chain_ids: List[str] = []
+    b_factor: List[float] = []
+    coords: List[List[float]] = []
+
+    chain_set = set(chains) if chains else None
+
+    with open(filename, "r") as fh:
+        for line in fh:
+            if not line.startswith("ATOM"):
+                continue
+            tokens = line.split()
+            if len(tokens) < 15:
+                # Not enough columns to parse
+                continue
+            # Chain identifier appears in different columns depending on the
+            # originating software.  Try a few possibilities, falling back to
+            # the label asym id (token 6) used by PyMOL exports in this repo.
+            chain = ""
+            if len(tokens) >= 7:
+                chain = tokens[6]
+            if chain in {"", "."}:
+                if len(tokens) >= 19:
+                    chain = tokens[18]
+                elif len(tokens) >= 17:
+                    chain = tokens[16]
+            if chain_set and chain not in chain_set:
+                continue
+            atom_nums.append(int(tokens[1]))
+            atom_list.append(tokens[3])
+            chain_ids.append(chain)
+            coords.append([float(tokens[10]), float(tokens[11]), float(tokens[12])])
+            b_factor.append(float(tokens[14]))
+
+    xyz = np.asarray(coords, dtype=float).T if coords else np.empty((3, 0))
+    atom_nums_arr = np.asarray(atom_nums, dtype=int)
+    b_factor_arr = np.asarray(b_factor, dtype=float)
+    return xyz, atom_nums_arr, atom_list, b_factor_arr, chain_ids

--- a/src/smap_tools_python/pdb.py
+++ b/src/smap_tools_python/pdb.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import numpy as np
+from typing import Dict, List, Any
+
+
+def read_pdb_file(filename: str) -> Dict[str, Any]:
+    """Read an ASCII ``.pdb`` file.
+
+    This is a lightweight parser that extracts atom records and a handful of
+    commonly used fields.  The return value mirrors MATLAB's ``read_pdb_file``
+    helper and provides a dictionary containing atom coordinates and assorted
+    metadata.
+    """
+    with open(filename, "r") as fh:
+        split_lines = fh.read().splitlines()
+
+    atom_list: List[str] = []
+    b_factor: List[float] = []
+    chain_ids: List[str] = []
+    res_name: List[str] = []
+    occ: List[float] = []
+    inds: List[int] = []
+    header: List[str] = []
+    header_inds: List[int] = []
+    line_type: List[int] = []
+    xyz: List[List[float]] = []
+
+    pdb_data = {
+        "atomType": [],
+        "atomNum": [],
+        "atomName": [],
+        "resName": [],
+        "chain": [],
+        "resNum": [],
+        "X": [],
+        "Y": [],
+        "Z": [],
+        "b_factor": [],
+        "comment": [],
+        "filler": [],
+        "occ": [],
+        "line": split_lines,
+    }
+
+    for idx, line in enumerate(split_lines, start=1):
+        record = line[0:6].strip()
+        if record in {"ATOM", "HETATM", "TER"}:
+            try:
+                pdb_data["atomType"].append(line[0:6])
+                pdb_data["atomNum"].append(line[6:11])
+                pdb_data["atomName"].append(line[12:16])
+                pdb_data["resName"].append(line[17:20])
+                pdb_data["chain"].append(line[21:22])
+                pdb_data["resNum"].append(line[22:26])
+                pdb_data["filler"].append(line[27:30])
+                pdb_data["X"].append(line[30:38])
+                pdb_data["Y"].append(line[38:46])
+                pdb_data["Z"].append(line[46:54])
+                pdb_data["occ"].append(line[54:60])
+                pdb_data["b_factor"].append(line[60:66])
+                pdb_data["comment"].append(line[66:])
+
+                x = float(line[30:38])
+                y = float(line[38:46])
+                z = float(line[46:54])
+                xyz.append([x, y, z])
+                atom_list.append(line[12:16].strip())
+                chain_ids.append(line[21:22].strip())
+                res_name.append(line[17:20].strip())
+                b_factor.append(float(line[60:66]))
+                occ.append(float(line[54:60]))
+                inds.append(idx)
+                line_type.append(1)
+            except ValueError:
+                header.append(line)
+                header_inds.append(idx)
+                line_type.append(0)
+        else:
+            header.append(line)
+            header_inds.append(idx)
+            line_type.append(0)
+
+    xyz_arr = np.asarray(xyz, dtype=float).T if xyz else np.empty((3, 0))
+    b_factor_arr = np.asarray(b_factor, dtype=float)
+    occ_arr = np.asarray(occ, dtype=float)
+
+    return {
+        "xyz": xyz_arr,
+        "atomList": atom_list,
+        "bFactor": b_factor_arr,
+        "chainIDs": chain_ids,
+        "resName": res_name,
+        "occ": occ_arr,
+        "inds": inds,
+        "header": header,
+        "headerInds": header_inds,
+        "lineType": line_type,
+        "PDBdata": pdb_data,
+        "splitLines": split_lines,
+    }

--- a/src/smap_tools_python/ri.py
+++ b/src/smap_tools_python/ri.py
@@ -1,0 +1,73 @@
+"""Image reading utilities translating MATLAB's ``ri`` and ``tr`` helpers."""
+from __future__ import annotations
+
+from pathlib import Path
+import numpy as np
+
+from .mrc import read_mrc
+
+try:  # pragma: no cover - optional dependency
+    import tifffile
+except Exception:  # pragma: no cover
+    tifffile = None
+
+
+def tr(filename: str | Path):
+    """Read a TIFF file returning an array shaped ``(H, W, N)``.
+
+    Parameters
+    ----------
+    filename : str or pathlib.Path
+        Path to the TIFF file.  If no extension is provided ``.tif`` is
+        appended automatically.
+
+    Returns
+    -------
+    numpy.ndarray
+        Image data with the frame axis last, matching the MATLAB ``tr``
+        helper.  Single-frame images retain a third axis of length one.
+    """
+
+    if tifffile is None:  # pragma: no cover
+        raise ImportError("tifffile is required to read TIFF files")
+
+    path = Path(filename)
+    if path.suffix == "":
+        path = path.with_suffix(".tif")
+
+    arr = tifffile.imread(str(path))
+    if arr.ndim == 2:
+        arr = arr[..., np.newaxis]
+    else:
+        arr = np.moveaxis(arr, 0, -1)
+    return arr
+
+
+def ri(filename: str | Path):
+    """Read an image or volume in TIFF or MRC format.
+
+    Parameters
+    ----------
+    filename : str or pathlib.Path
+        Input file path.
+
+    Returns
+    -------
+    tuple
+        ``(data, info)`` where ``info`` is a dictionary that may contain
+        ``"voxel_size"`` for MRC files.  For TIFF files the dictionary is
+        empty.
+    """
+
+    path = Path(filename)
+    ext = path.suffix.lower()
+
+    if ext in (".tif", ".tiff", ""):
+        data = tr(path)
+        return data, {}
+    if ext == ".mrc":
+        data, voxel = read_mrc(str(path))
+        return data, {"voxel_size": voxel}
+    if ext == ".dm4":  # pragma: no cover - not yet implemented
+        raise NotImplementedError("DM4 reading not implemented")
+    raise ValueError(f"Unknown file type: {ext}")

--- a/tests/test_ri.py
+++ b/tests/test_ri.py
@@ -1,0 +1,37 @@
+import numpy as np
+import pytest
+
+mrcfile = pytest.importorskip("mrcfile")
+from smap_tools_python import tr, ri
+
+
+def test_tr_reads_multiframe_tiff(tmp_path):
+    tifffile = pytest.importorskip("tifffile")
+    data = np.arange(12, dtype=np.uint8).reshape(3, 4, 1)
+    data = np.concatenate([data, data + 1], axis=2)
+    path = tmp_path / "test.tif"
+    tifffile.imwrite(str(path), np.moveaxis(data, -1, 0))
+    out = tr(path)
+    assert out.shape == data.shape
+    assert np.all(out == data)
+
+
+def test_ri_handles_mrc(tmp_path):
+    arr = np.arange(8, dtype=np.float32).reshape(2, 2, 2)
+    mrc_path = tmp_path / "vol.mrc"
+    with mrcfile.new(mrc_path, overwrite=True) as mrc:
+        mrc.set_data(arr)
+        mrc.voxel_size = (1.5, 1.5, 1.5)
+    data, info = ri(mrc_path)
+    assert np.allclose(data, arr)
+    assert info["voxel_size"] == (1.5, 1.5, 1.5)
+
+
+def test_ri_handles_tiff(tmp_path):
+    tifffile = pytest.importorskip("tifffile")
+    arr = np.arange(6, dtype=np.uint8).reshape(3, 2)
+    path = tmp_path / "im.tif"
+    tifffile.imwrite(str(path), arr)
+    data, info = ri(path)
+    assert data.shape == (3, 2, 1)
+    assert info == {}

--- a/tests/test_struct_io.py
+++ b/tests/test_struct_io.py
@@ -1,0 +1,30 @@
+import numpy as np
+import pathlib
+
+from smap_tools_python import read_cif_file, read_pdb_file
+
+MODEL_DIR = pathlib.Path(__file__).resolve().parent.parent / "model"
+
+
+def test_read_cif_file_basic():
+    cif_path = MODEL_DIR / "6ek0_LSU.cif"
+    xyz, atom_nums, atom_list, bfac, chains = read_cif_file(str(cif_path), chains=["A"])
+    assert xyz.shape[0] == 3
+    assert len(atom_nums) == xyz.shape[1]
+    assert atom_nums[0] == 1
+    assert atom_list[0] == "C5'"
+    assert chains[0] == "A"
+    assert np.allclose(xyz[:, 0], [-20.637, 30.989, 98.976])
+    assert np.isclose(bfac[0], 109.77)
+
+
+def test_read_pdb_file_basic():
+    pdb_path = MODEL_DIR / "5j5b_monster.pdb"
+    data = read_pdb_file(str(pdb_path))
+    xyz = data["xyz"]
+    assert xyz.shape[0] == 3
+    assert data["atomList"][0] == "N"
+    assert data["chainIDs"][0] == "V"
+    assert np.allclose(xyz[:, 0], [29.342, -33.809, -75.427])
+    assert np.isclose(data["bFactor"][0], 142.22)
+    assert np.isclose(data["occ"][0], 1.00)


### PR DESCRIPTION
## Summary
- port MATLAB helpers for parsing CIF and PDB files
- expose `read_cif_file` and `read_pdb_file` through package API
- test reading sample structure files

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68bd7b349fec8328b35da0a5495b4346