### PR TITLE
Add phase shift and tiling utilities

### DIFF
--- a/src/smap_tools_python/__init__.py
+++ b/src/smap_tools_python/__init__.py
@@ -13,6 +13,9 @@ from .ctf import ctf
 from .crop_pad import crop_or_pad, cutj, extendj
 from .resize_for_fft import resize_for_fft
 from .pad_for_fft import pad_for_fft
+from .phase_shift import apply_phase_shifts
+from .crop_patch import crop_patch_from_image
+from .tile_images import tile_images
 from .rotate import (
     rotate3d_vector,
     rotate2d_matrix,
@@ -26,6 +29,7 @@ from .mean import mean
 from .nm import nm
 from .getcp import get_center_pixel, getcp
 from .mrc import read_mrc, write_mrc
+from .ri import tr, ri
 from .bindata import bindata
 from .particle_diameter import particle_diameter
 from .whoami import whoami
@@ -43,6 +47,8 @@ from .estimate_snr import estimate_snr
 from .ts import ts
 from .measure_qd import measure_qd
 from .mw import mw
+from .cif import read_cif_file
+from .pdb import read_pdb_file
 
 __all__ = [
     "variable_cos_mask",
@@ -61,6 +67,9 @@ __all__ = [
     "crop_or_pad",
     "cutj",
     "extendj",
+    "apply_phase_shifts",
+    "crop_patch_from_image",
+    "tile_images",
     "resize_for_fft",
     "pad_for_fft",
     "rotate3d_vector",
@@ -78,6 +87,8 @@ __all__ = [
     "getcp",
     "read_mrc",
     "write_mrc",
+    "tr",
+    "ri",
     "bindata",
     "particle_diameter",
     "whoami",
@@ -91,6 +102,8 @@ __all__ = [
     "ts",
     "measure_qd",
     "mw",
+    "read_cif_file",
+    "read_pdb_file",
     "write_dat",
     "read_dat_file",
     "write_rotations_file",

--- a/src/smap_tools_python/cif.py
+++ b/src/smap_tools_python/cif.py
@@ -1,0 +1,60 @@
+import numpy as np
+from typing import Sequence, Tuple, List, Optional
+
+
+def read_cif_file(filename: str, chains: Optional[Sequence[str]] = None) -> Tuple[np.ndarray, np.ndarray, List[str], np.ndarray, List[str]]:
+    """Parse a minimal subset of a ``.cif`` file.
+
+    Parameters
+    ----------
+    filename:
+        Path to a CIF file.
+    chains:
+        Optional iterable of chain identifiers to keep.  All chains are
+        returned when ``None``.
+
+    Returns
+    -------
+    xyz, atom_nums, atom_list, b_factor, chain_ids
+        ``xyz`` is a 3×N array of coordinates in Å and the other outputs are
+        per-atom properties mirroring the MATLAB ``read_cif_file`` helper.
+    """
+    atom_nums: List[int] = []
+    atom_list: List[str] = []
+    chain_ids: List[str] = []
+    b_factor: List[float] = []
+    coords: List[List[float]] = []
+
+    chain_set = set(chains) if chains else None
+
+    with open(filename, "r") as fh:
+        for line in fh:
+            if not line.startswith("ATOM"):
+                continue
+            tokens = line.split()
+            if len(tokens) < 15:
+                # Not enough columns to parse
+                continue
+            # Chain identifier appears in different columns depending on the
+            # originating software.  Try a few possibilities, falling back to
+            # the label asym id (token 6) used by PyMOL exports in this repo.
+            chain = ""
+            if len(tokens) >= 7:
+                chain = tokens[6]
+            if chain in {"", "."}:
+                if len(tokens) >= 19:
+                    chain = tokens[18]
+                elif len(tokens) >= 17:
+                    chain = tokens[16]
+            if chain_set and chain not in chain_set:
+                continue
+            atom_nums.append(int(tokens[1]))
+            atom_list.append(tokens[3])
+            chain_ids.append(chain)
+            coords.append([float(tokens[10]), float(tokens[11]), float(tokens[12])])
+            b_factor.append(float(tokens[14]))
+
+    xyz = np.asarray(coords, dtype=float).T if coords else np.empty((3, 0))
+    atom_nums_arr = np.asarray(atom_nums, dtype=int)
+    b_factor_arr = np.asarray(b_factor, dtype=float)
+    return xyz, atom_nums_arr, atom_list, b_factor_arr, chain_ids

--- a/src/smap_tools_python/crop_patch.py
+++ b/src/smap_tools_python/crop_patch.py
@@ -1,0 +1,38 @@
+import numpy as np
+from .phase_shift import apply_phase_shifts
+from .crop_pad import cutj
+
+
+def crop_patch_from_image(arr, half_dim, row_col_inds):
+    """Extract a square patch centered at ``row_col_inds``.
+
+    The patch is taken from ``arr`` by first shifting the image so that the
+    pixel specified by ``row_col_inds`` moves to the image centre, then cropping
+    a region of size ``(2*half_dim, 2*half_dim)`` around the centre.  Indices are
+    zero-based.
+
+    Parameters
+    ----------
+    arr : array_like
+        Input 2-D image.
+    half_dim : int
+        Half the side length of the desired patch. The output patch will be of
+        size ``2*half_dim``.
+    row_col_inds : tuple of int
+        Row and column index of the pixel that should be moved to the centre
+        before cropping.
+
+    Returns
+    -------
+    numpy.ndarray
+        Extracted image patch.
+    """
+    arr = np.asarray(arr)
+    center = np.array(arr.shape[:2]) // 2
+    shifts = center - np.asarray(row_col_inds, dtype=float)
+    shifted = apply_phase_shifts(arr, shifts)
+    if np.isrealobj(arr):
+        shifted = shifted.real
+    size = int(half_dim) * 2
+    patch = cutj(shifted, (size, size))
+    return patch

--- a/src/smap_tools_python/pdb.py
+++ b/src/smap_tools_python/pdb.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import numpy as np
+from typing import Dict, List, Any
+
+
+def read_pdb_file(filename: str) -> Dict[str, Any]:
+    """Read an ASCII ``.pdb`` file.
+
+    This is a lightweight parser that extracts atom records and a handful of
+    commonly used fields.  The return value mirrors MATLAB's ``read_pdb_file``
+    helper and provides a dictionary containing atom coordinates and assorted
+    metadata.
+    """
+    with open(filename, "r") as fh:
+        split_lines = fh.read().splitlines()
+
+    atom_list: List[str] = []
+    b_factor: List[float] = []
+    chain_ids: List[str] = []
+    res_name: List[str] = []
+    occ: List[float] = []
+    inds: List[int] = []
+    header: List[str] = []
+    header_inds: List[int] = []
+    line_type: List[int] = []
+    xyz: List[List[float]] = []
+
+    pdb_data = {
+        "atomType": [],
+        "atomNum": [],
+        "atomName": [],
+        "resName": [],
+        "chain": [],
+        "resNum": [],
+        "X": [],
+        "Y": [],
+        "Z": [],
+        "b_factor": [],
+        "comment": [],
+        "filler": [],
+        "occ": [],
+        "line": split_lines,
+    }
+
+    for idx, line in enumerate(split_lines, start=1):
+        record = line[0:6].strip()
+        if record in {"ATOM", "HETATM", "TER"}:
+            try:
+                pdb_data["atomType"].append(line[0:6])
+                pdb_data["atomNum"].append(line[6:11])
+                pdb_data["atomName"].append(line[12:16])
+                pdb_data["resName"].append(line[17:20])
+                pdb_data["chain"].append(line[21:22])
+                pdb_data["resNum"].append(line[22:26])
+                pdb_data["filler"].append(line[27:30])
+                pdb_data["X"].append(line[30:38])
+                pdb_data["Y"].append(line[38:46])
+                pdb_data["Z"].append(line[46:54])
+                pdb_data["occ"].append(line[54:60])
+                pdb_data["b_factor"].append(line[60:66])
+                pdb_data["comment"].append(line[66:])
+
+                x = float(line[30:38])
+                y = float(line[38:46])
+                z = float(line[46:54])
+                xyz.append([x, y, z])
+                atom_list.append(line[12:16].strip())
+                chain_ids.append(line[21:22].strip())
+                res_name.append(line[17:20].strip())
+                b_factor.append(float(line[60:66]))
+                occ.append(float(line[54:60]))
+                inds.append(idx)
+                line_type.append(1)
+            except ValueError:
+                header.append(line)
+                header_inds.append(idx)
+                line_type.append(0)
+        else:
+            header.append(line)
+            header_inds.append(idx)
+            line_type.append(0)
+
+    xyz_arr = np.asarray(xyz, dtype=float).T if xyz else np.empty((3, 0))
+    b_factor_arr = np.asarray(b_factor, dtype=float)
+    occ_arr = np.asarray(occ, dtype=float)
+
+    return {
+        "xyz": xyz_arr,
+        "atomList": atom_list,
+        "bFactor": b_factor_arr,
+        "chainIDs": chain_ids,
+        "resName": res_name,
+        "occ": occ_arr,
+        "inds": inds,
+        "header": header,
+        "headerInds": header_inds,
+        "lineType": line_type,
+        "PDBdata": pdb_data,
+        "splitLines": split_lines,
+    }

--- a/src/smap_tools_python/phase_shift.py
+++ b/src/smap_tools_python/phase_shift.py
@@ -1,0 +1,27 @@
+import numpy as np
+from numpy.fft import fftn, ifftn
+from scipy.ndimage import fourier_shift
+
+
+def apply_phase_shifts(arr, shifts):
+    """Shift an array by subpixel amounts using Fourier phase shifts.
+
+    Parameters
+    ----------
+    arr : array_like
+        Input array to shift. Can be N-dimensional.
+    shifts : array_like
+        Sequence of length ``arr.ndim`` giving shifts along each axis in
+        pixels. Positive values shift toward higher indices.
+
+    Returns
+    -------
+    numpy.ndarray
+        The shifted array, potentially complex when subpixel shifts are used.
+    """
+    arr = np.asarray(arr)
+    shifts = np.asarray(shifts, dtype=float)
+    if shifts.shape != (arr.ndim,):
+        raise ValueError("shifts must match the number of array dimensions")
+    shifted_fft = fourier_shift(fftn(arr), shifts)
+    return ifftn(shifted_fft)

--- a/src/smap_tools_python/ri.py
+++ b/src/smap_tools_python/ri.py
@@ -1,0 +1,73 @@
+"""Image reading utilities translating MATLAB's ``ri`` and ``tr`` helpers."""
+from __future__ import annotations
+
+from pathlib import Path
+import numpy as np
+
+from .mrc import read_mrc
+
+try:  # pragma: no cover - optional dependency
+    import tifffile
+except Exception:  # pragma: no cover
+    tifffile = None
+
+
+def tr(filename: str | Path):
+    """Read a TIFF file returning an array shaped ``(H, W, N)``.
+
+    Parameters
+    ----------
+    filename : str or pathlib.Path
+        Path to the TIFF file.  If no extension is provided ``.tif`` is
+        appended automatically.
+
+    Returns
+    -------
+    numpy.ndarray
+        Image data with the frame axis last, matching the MATLAB ``tr``
+        helper.  Single-frame images retain a third axis of length one.
+    """
+
+    if tifffile is None:  # pragma: no cover
+        raise ImportError("tifffile is required to read TIFF files")
+
+    path = Path(filename)
+    if path.suffix == "":
+        path = path.with_suffix(".tif")
+
+    arr = tifffile.imread(str(path))
+    if arr.ndim == 2:
+        arr = arr[..., np.newaxis]
+    else:
+        arr = np.moveaxis(arr, 0, -1)
+    return arr
+
+
+def ri(filename: str | Path):
+    """Read an image or volume in TIFF or MRC format.
+
+    Parameters
+    ----------
+    filename : str or pathlib.Path
+        Input file path.
+
+    Returns
+    -------
+    tuple
+        ``(data, info)`` where ``info`` is a dictionary that may contain
+        ``"voxel_size"`` for MRC files.  For TIFF files the dictionary is
+        empty.
+    """
+
+    path = Path(filename)
+    ext = path.suffix.lower()
+
+    if ext in (".tif", ".tiff", ""):
+        data = tr(path)
+        return data, {}
+    if ext == ".mrc":
+        data, voxel = read_mrc(str(path))
+        return data, {"voxel_size": voxel}
+    if ext == ".dm4":  # pragma: no cover - not yet implemented
+        raise NotImplementedError("DM4 reading not implemented")
+    raise ValueError(f"Unknown file type: {ext}")

--- a/src/smap_tools_python/tile_images.py
+++ b/src/smap_tools_python/tile_images.py
@@ -1,0 +1,35 @@
+import numpy as np
+
+
+def tile_images(images):
+    """Compose a tiled image from three projections.
+
+    Parameters
+    ----------
+    images : sequence or array
+        Either a list of three 2‑D arrays or a 3‑D array with the third
+        dimension of size three.
+
+    Returns
+    -------
+    numpy.ndarray
+        A ``(2N, 2N)`` tiled image where ``N`` is the edge length of the input
+        images. The bottom-right quadrant is filled with the median of the
+        provided data.
+    """
+    if isinstance(images, np.ndarray):
+        if images.ndim != 3 or images.shape[2] != 3:
+            raise ValueError("expected array of shape (N, N, 3)")
+        proj = [images[:, :, i] for i in range(3)]
+    else:
+        if len(images) != 3:
+            raise ValueError("expected three images")
+        proj = [np.asarray(im) for im in images]
+    n = proj[0].shape[0]
+    out = np.full((2 * n, 2 * n), np.nan, dtype=float)
+    out[0:n, 0:n] = proj[0]
+    out[0:n, n:2 * n] = proj[1]
+    out[n:2 * n, 0:n] = proj[2]
+    median = np.nanmedian(out)
+    out[np.isnan(out)] = median
+    return out

--- a/tests/test_crop_patch.py
+++ b/tests/test_crop_patch.py
@@ -1,0 +1,14 @@
+import numpy as np
+from smap_tools_python.crop_patch import crop_patch_from_image
+
+
+def test_crop_patch_from_image():
+    arr = np.arange(100).reshape(10, 10)
+    half = 2
+    row_col = (2, 7)
+    patch = crop_patch_from_image(arr, half, row_col)
+    center = np.array(arr.shape) // 2
+    shift = center - np.array(row_col)
+    expected_full = np.roll(arr, shift, axis=(0, 1))
+    expected = expected_full[center[0]-half:center[0]+half, center[1]-half:center[1]+half]
+    assert np.allclose(patch, expected)

--- a/tests/test_phase_shift.py
+++ b/tests/test_phase_shift.py
@@ -1,0 +1,18 @@
+import numpy as np
+from smap_tools_python.phase_shift import apply_phase_shifts
+
+
+def test_apply_phase_shifts_integer():
+    arr = np.arange(16).reshape(4, 4)
+    out = apply_phase_shifts(arr, (1, -1))
+    expected = np.roll(arr, (1, -1), axis=(0, 1))
+    assert np.allclose(out, expected)
+
+
+def test_apply_phase_shifts_invertible():
+    rng = np.random.default_rng(0)
+    arr = rng.standard_normal((8, 8))
+    shift = (0.3, -0.7)
+    shifted = apply_phase_shifts(arr, shift)
+    restored = apply_phase_shifts(shifted, (-shift[0], -shift[1]))
+    assert np.allclose(restored, arr)

--- a/tests/test_ri.py
+++ b/tests/test_ri.py
@@ -1,0 +1,37 @@
+import numpy as np
+import pytest
+
+mrcfile = pytest.importorskip("mrcfile")
+from smap_tools_python import tr, ri
+
+
+def test_tr_reads_multiframe_tiff(tmp_path):
+    tifffile = pytest.importorskip("tifffile")
+    data = np.arange(12, dtype=np.uint8).reshape(3, 4, 1)
+    data = np.concatenate([data, data + 1], axis=2)
+    path = tmp_path / "test.tif"
+    tifffile.imwrite(str(path), np.moveaxis(data, -1, 0))
+    out = tr(path)
+    assert out.shape == data.shape
+    assert np.all(out == data)
+
+
+def test_ri_handles_mrc(tmp_path):
+    arr = np.arange(8, dtype=np.float32).reshape(2, 2, 2)
+    mrc_path = tmp_path / "vol.mrc"
+    with mrcfile.new(mrc_path, overwrite=True) as mrc:
+        mrc.set_data(arr)
+        mrc.voxel_size = (1.5, 1.5, 1.5)
+    data, info = ri(mrc_path)
+    assert np.allclose(data, arr)
+    assert info["voxel_size"] == (1.5, 1.5, 1.5)
+
+
+def test_ri_handles_tiff(tmp_path):
+    tifffile = pytest.importorskip("tifffile")
+    arr = np.arange(6, dtype=np.uint8).reshape(3, 2)
+    path = tmp_path / "im.tif"
+    tifffile.imwrite(str(path), arr)
+    data, info = ri(path)
+    assert data.shape == (3, 2, 1)
+    assert info == {}

--- a/tests/test_struct_io.py
+++ b/tests/test_struct_io.py
@@ -1,0 +1,30 @@
+import numpy as np
+import pathlib
+
+from smap_tools_python import read_cif_file, read_pdb_file
+
+MODEL_DIR = pathlib.Path(__file__).resolve().parent.parent / "model"
+
+
+def test_read_cif_file_basic():
+    cif_path = MODEL_DIR / "6ek0_LSU.cif"
+    xyz, atom_nums, atom_list, bfac, chains = read_cif_file(str(cif_path), chains=["A"])
+    assert xyz.shape[0] == 3
+    assert len(atom_nums) == xyz.shape[1]
+    assert atom_nums[0] == 1
+    assert atom_list[0] == "C5'"
+    assert chains[0] == "A"
+    assert np.allclose(xyz[:, 0], [-20.637, 30.989, 98.976])
+    assert np.isclose(bfac[0], 109.77)
+
+
+def test_read_pdb_file_basic():
+    pdb_path = MODEL_DIR / "5j5b_monster.pdb"
+    data = read_pdb_file(str(pdb_path))
+    xyz = data["xyz"]
+    assert xyz.shape[0] == 3
+    assert data["atomList"][0] == "N"
+    assert data["chainIDs"][0] == "V"
+    assert np.allclose(xyz[:, 0], [29.342, -33.809, -75.427])
+    assert np.isclose(data["bFactor"][0], 142.22)
+    assert np.isclose(data["occ"][0], 1.00)

--- a/tests/test_tile_images.py
+++ b/tests/test_tile_images.py
@@ -1,0 +1,16 @@
+import numpy as np
+from smap_tools_python.tile_images import tile_images
+
+
+def test_tile_images_basic():
+    im1 = np.array([[1, 2], [3, 4]])
+    im2 = np.array([[5, 6], [7, 8]])
+    im3 = np.array([[9, 10], [11, 12]])
+    out = tile_images([im1, im2, im3])
+    expected = np.array([
+        [1, 2, 5, 6],
+        [3, 4, 7, 8],
+        [9, 10, 6.5, 6.5],
+        [11, 12, 6.5, 6.5],
+    ])
+    assert np.allclose(out, expected)


### PR DESCRIPTION
## Summary
- support subpixel array translations via new `apply_phase_shifts`
- add `crop_patch_from_image` for centered patch extraction
- provide `tile_images` helper for composing three projections

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68bd7b349fec8328b35da0a5495b4346