### PR TITLE
Add cross-correlation, clustering, and polar transforms

### DIFF
--- a/src/smap_tools_python/__init__.py
+++ b/src/smap_tools_python/__init__.py
@@ -13,6 +13,9 @@ from .ctf import ctf
 from .crop_pad import crop_or_pad, cutj, extendj
 from .resize_for_fft import resize_for_fft
 from .pad_for_fft import pad_for_fft
+from .phase_shift import apply_phase_shifts
+from .crop_patch import crop_patch_from_image
+from .tile_images import tile_images
 from .rotate import (
     rotate3d_vector,
     rotate2d_matrix,
@@ -21,11 +24,14 @@ from .rotate import (
     normalize_rotation_matrices,
 )
 from .radial import radial_mean, radial_average, radial_max
+from .polar_image import polar_image
+from .r_theta import r_theta
 from .g2 import g2
 from .mean import mean
 from .nm import nm
 from .getcp import get_center_pixel, getcp
 from .mrc import read_mrc, write_mrc
+from .ri import tr, ri
 from .bindata import bindata
 from .particle_diameter import particle_diameter
 from .whoami import whoami
@@ -41,8 +47,15 @@ from .get_psd import get_psd
 from .assign_jobs import assign_jobs
 from .estimate_snr import estimate_snr
 from .ts import ts
+from .bump_q import bump_q
+from .calculate_search_grid import calculate_search_grid
 from .measure_qd import measure_qd
 from .mw import mw
+from .cif import read_cif_file
+from .pdb import read_pdb_file
+from .ccf import ccf
+from .cluster_im_by_thr import cluster_im_by_thr
+from .dust import dust
 
 __all__ = [
     "variable_cos_mask",
@@ -61,6 +74,9 @@ __all__ = [
     "crop_or_pad",
     "cutj",
     "extendj",
+    "apply_phase_shifts",
+    "crop_patch_from_image",
+    "tile_images",
     "resize_for_fft",
     "pad_for_fft",
     "rotate3d_vector",
@@ -71,6 +87,8 @@ __all__ = [
     "radial_mean",
     "radial_average",
     "radial_max",
+    "polar_image",
+    "r_theta",
     "g2",
     "mean",
     "nm",
@@ -78,6 +96,8 @@ __all__ = [
     "getcp",
     "read_mrc",
     "write_mrc",
+    "tr",
+    "ri",
     "bindata",
     "particle_diameter",
     "whoami",
@@ -89,8 +109,15 @@ __all__ = [
     "assign_jobs",
     "estimate_snr",
     "ts",
+    "bump_q",
+    "calculate_search_grid",
     "measure_qd",
     "mw",
+    "read_cif_file",
+    "read_pdb_file",
+    "ccf",
+    "cluster_im_by_thr",
+    "dust",
     "write_dat",
     "read_dat_file",
     "write_rotations_file",

--- a/src/smap_tools_python/bump_q.py
+++ b/src/smap_tools_python/bump_q.py
@@ -1,0 +1,49 @@
+import numpy as np
+from .quaternion import Quaternion
+from .rotate import normalize_rotation_matrices
+
+
+def _to_rotation_matrices(q):
+    """Convert various rotation representations to a (3,3,N) array."""
+    if isinstance(q, Quaternion):
+        return q.to_rotation_matrix()[:, :, np.newaxis]
+    arr = np.asarray(q, dtype=float)
+    if arr.ndim == 2 and arr.shape == (3, 3):
+        return arr[:, :, np.newaxis]
+    if arr.ndim == 3 and arr.shape[0:2] == (3, 3):
+        return arr
+    if arr.shape[-1] == 4:
+        arr = arr.reshape(-1, 4)
+        mats = np.stack([Quaternion(*row).to_rotation_matrix() for row in arr], axis=2)
+        return mats
+    raise ValueError("Unsupported rotation representation")
+
+
+def bump_q(q_in, q_bump):
+    """Compose two sets of rotations.
+
+    Parameters
+    ----------
+    q_in : array_like or Quaternion or sequence
+        Initial rotations. Can be rotation matrices of shape ``(3,3,N)`` or
+        quaternions of shape ``(N,4)`` or ``(4,N)``.
+    q_bump : array_like or Quaternion or sequence
+        Rotations to apply after ``q_in``.
+
+    Returns
+    -------
+    numpy.ndarray
+        Rotation matrices for all combinations of ``q_bump * q_in`` with
+        shape ``(3,3,N_in*N_bump)``.
+    """
+    R_in = _to_rotation_matrices(q_in)
+    R_bump = _to_rotation_matrices(q_bump)
+    n_in = R_in.shape[2]
+    n_bump = R_bump.shape[2]
+    out = np.empty((3, 3, n_in * n_bump), dtype=float)
+    idx = 0
+    for i in range(n_in):
+        for j in range(n_bump):
+            out[:, :, idx] = R_bump[:, :, j] @ R_in[:, :, i]
+            idx += 1
+    return normalize_rotation_matrices(np.transpose(out,(2,0,1))).transpose(1,2,0)

--- a/src/smap_tools_python/calculate_search_grid.py
+++ b/src/smap_tools_python/calculate_search_grid.py
@@ -1,0 +1,109 @@
+import numpy as np
+from .rotate import normalize_rotation_matrices
+
+
+_def_psi_max = 358
+
+
+def calculate_search_grid(symmetry_symbol, angular_step_size, psi_step, psi_max=_def_psi_max):
+    """Generate Euler angles and rotation matrices for a symmetry-limited grid.
+
+    Parameters
+    ----------
+    symmetry_symbol : str
+        Symmetry specifier (e.g., ``'C1'``, ``'D2'``, ``'T'``, ``'O'``, ``'I'``).
+    angular_step_size : float
+        Sampling step for polar angles in degrees.
+    psi_step : float
+        Sampling step for ``psi`` angle in degrees.
+    psi_max : float, optional
+        Maximum ``psi`` angle. Defaults to 358 to mimic MATLAB behavior.
+
+    Returns
+    -------
+    tuple
+        ``(RM, EA)`` where ``RM`` are rotation matrices of shape ``(3,3,N)`` and
+        ``EA`` are Euler angles in degrees as a ``3×N`` array ``[phi; theta; psi]``.
+    """
+    symmetry_symbol = symmetry_symbol.upper()
+    symmetry_number = 1
+    if len(symmetry_symbol) > 1:
+        try:
+            symmetry_number = int(symmetry_symbol[1:])
+        except ValueError:
+            pass
+    sym_type = symmetry_symbol[0]
+    phi_start = 0
+
+    if sym_type == "C":
+        phi_max = 360.0 / symmetry_number
+        theta_max = 90.0
+        test_mirror = True
+    elif sym_type == "D":
+        phi_max = 360.0 / symmetry_number
+        theta_max = 90.0
+        test_mirror = False
+    elif sym_type == "T":
+        phi_max = 180.0
+        theta_max = 54.7
+        test_mirror = False
+    elif sym_type == "O":
+        phi_max = 90.0
+        theta_max = 54.7
+        test_mirror = False
+    elif sym_type == "I":
+        phi_max = 180.0
+        theta_max = 31.7
+        test_mirror = False
+    else:
+        raise ValueError("Unrecognized symmetry symbol")
+
+    psi_vector = np.arange(0, psi_max + 1e-3, psi_step)
+
+    theta_step = theta_max / np.floor(theta_max / angular_step_size + 0.5)
+    theta_values = np.arange(0, theta_max + theta_step / 2 + 1e-3, theta_step)
+
+    euler_angles = []
+    for theta in theta_values:
+        if theta in (0, 180):
+            phi_step = phi_max
+        else:
+            phi_step = angular_step_size / np.sin(np.deg2rad(theta))
+            if phi_step > phi_max:
+                phi_step = phi_max
+            phi_step = phi_max / np.floor(phi_max / phi_step + 0.5)
+        phi_values = np.arange(0, phi_max + 1e-3, phi_step)
+        for phi in phi_values:
+            for psi in psi_vector:
+                euler_angles.append([phi + phi_start, theta, psi])
+    EA = np.array(euler_angles, dtype=float).T
+
+    phi = np.deg2rad(EA[0])
+    theta = np.deg2rad(EA[1])
+    psi = np.deg2rad(EA[2])
+
+    n = EA.shape[1]
+    RM = np.zeros((3, 3, n), dtype=float)
+    c_phi, c_theta, c_psi = np.cos(phi), np.cos(theta), np.cos(psi)
+    s_phi, s_theta, s_psi = np.sin(phi), np.sin(theta), np.sin(psi)
+    RM[0, 0, :] = c_phi * c_theta * c_psi - s_phi * s_psi
+    RM[0, 1, :] = s_phi * c_theta * c_psi + c_phi * s_psi
+    RM[0, 2, :] = -s_theta * c_psi
+    RM[1, 0, :] = -c_phi * c_theta * s_psi - s_phi * c_psi
+    RM[1, 1, :] = -s_phi * c_theta * s_psi + c_phi * c_psi
+    RM[1, 2, :] = s_theta * s_psi
+    RM[2, 0, :] = s_theta * c_phi
+    RM[2, 1, :] = s_theta * s_phi
+    RM[2, 2, :] = c_theta
+
+    RM = normalize_rotation_matrices(np.transpose(RM,(2,0,1))).transpose(1,2,0)
+
+    if test_mirror:
+        R_flip = np.array([[1, 0, 0], [0, -1, 0], [0, 0, -1]], dtype=float)
+        RM_mirror = np.zeros_like(RM)
+        for j in range(RM.shape[2]):
+            RM_mirror[:, :, j] = RM[:, :, j] @ R_flip
+        RM_mirror = normalize_rotation_matrices(np.transpose(RM_mirror,(2,0,1))).transpose(1,2,0)
+        RM = np.concatenate([RM, RM_mirror], axis=2)
+
+    return RM, EA

--- a/src/smap_tools_python/ccf.py
+++ b/src/smap_tools_python/ccf.py
@@ -1,0 +1,48 @@
+import numpy as np
+from .crop_pad import crop_or_pad
+
+
+def ccf(image, templates):
+    """Cross-correlate an image with a stack of templates.
+
+    Parameters
+    ----------
+    image : ndarray, shape (M, N)
+        Input 2D image.
+    templates : ndarray, shape (M_t, N_t, K)
+        Stack of ``K`` templates.
+
+    Returns
+    -------
+    tuple of (ndarray, ndarray)
+        ``cc`` is the cross-correlation volume of shape ``(M, N, K)`` and
+        ``peaks`` is an array of peak values for each template.
+    """
+    image = np.asarray(image, dtype=float)
+    templates = np.asarray(templates, dtype=float)
+    if image.ndim != 2 or templates.ndim != 3:
+        raise ValueError("image must be 2D and templates 3D")
+
+    full_x, full_y = image.shape
+    full_xy = full_x * full_y
+
+    image = (image - image.mean()) / image.std()
+    image_f = np.fft.fftn(np.fft.ifftshift(image))
+
+    n_templates = templates.shape[2]
+    out = np.empty((full_x, full_y, n_templates), dtype=float)
+    peaks = np.empty(n_templates, dtype=float)
+
+    for i in range(n_templates):
+        temp = templates[:, :, i]
+        temp = (temp - np.median(temp)) / temp.std()
+        template = crop_or_pad(temp, image.shape, pad_value=0)
+        template_f = np.fft.fftn(np.fft.ifftshift(template))
+        v = np.sum(np.abs(template_f.ravel()) ** 2) / full_xy
+        denom = np.sqrt(v / full_xy)
+        template_f = template_f / denom
+        cc_f = image_f * np.conj(template_f)
+        temp_cc = np.real(np.fft.fftshift(np.fft.ifftn(cc_f))) / np.sqrt(full_xy)
+        out[:, :, i] = temp_cc
+        peaks[i] = temp_cc.max()
+    return out, peaks

--- a/src/smap_tools_python/cif.py
+++ b/src/smap_tools_python/cif.py
@@ -1,0 +1,60 @@
+import numpy as np
+from typing import Sequence, Tuple, List, Optional
+
+
+def read_cif_file(filename: str, chains: Optional[Sequence[str]] = None) -> Tuple[np.ndarray, np.ndarray, List[str], np.ndarray, List[str]]:
+    """Parse a minimal subset of a ``.cif`` file.
+
+    Parameters
+    ----------
+    filename:
+        Path to a CIF file.
+    chains:
+        Optional iterable of chain identifiers to keep.  All chains are
+        returned when ``None``.
+
+    Returns
+    -------
+    xyz, atom_nums, atom_list, b_factor, chain_ids
+        ``xyz`` is a 3×N array of coordinates in Å and the other outputs are
+        per-atom properties mirroring the MATLAB ``read_cif_file`` helper.
+    """
+    atom_nums: List[int] = []
+    atom_list: List[str] = []
+    chain_ids: List[str] = []
+    b_factor: List[float] = []
+    coords: List[List[float]] = []
+
+    chain_set = set(chains) if chains else None
+
+    with open(filename, "r") as fh:
+        for line in fh:
+            if not line.startswith("ATOM"):
+                continue
+            tokens = line.split()
+            if len(tokens) < 15:
+                # Not enough columns to parse
+                continue
+            # Chain identifier appears in different columns depending on the
+            # originating software.  Try a few possibilities, falling back to
+            # the label asym id (token 6) used by PyMOL exports in this repo.
+            chain = ""
+            if len(tokens) >= 7:
+                chain = tokens[6]
+            if chain in {"", "."}:
+                if len(tokens) >= 19:
+                    chain = tokens[18]
+                elif len(tokens) >= 17:
+                    chain = tokens[16]
+            if chain_set and chain not in chain_set:
+                continue
+            atom_nums.append(int(tokens[1]))
+            atom_list.append(tokens[3])
+            chain_ids.append(chain)
+            coords.append([float(tokens[10]), float(tokens[11]), float(tokens[12])])
+            b_factor.append(float(tokens[14]))
+
+    xyz = np.asarray(coords, dtype=float).T if coords else np.empty((3, 0))
+    atom_nums_arr = np.asarray(atom_nums, dtype=int)
+    b_factor_arr = np.asarray(b_factor, dtype=float)
+    return xyz, atom_nums_arr, atom_list, b_factor_arr, chain_ids

--- a/src/smap_tools_python/cluster_im_by_thr.py
+++ b/src/smap_tools_python/cluster_im_by_thr.py
@@ -1,0 +1,70 @@
+import numpy as np
+from scipy import ndimage
+
+
+def cluster_im_by_thr(image, index_image, threshold, rotations):
+    """Cluster connected pixels above a threshold and retrieve rotations.
+
+    Parameters
+    ----------
+    image : ndarray
+        2-D array of scores.
+    index_image : ndarray
+        Integer array mapping each pixel to an index in ``rotations``.
+    threshold : float
+        Minimum score to include a pixel in a cluster.
+    rotations : sequence
+        Sequence of rotation objects. Elements are selected via
+        ``index_image``.
+
+    Returns
+    -------
+    ss : list of dict
+        Cluster information with ``Area``, ``PixelList``, ``MaxVal`` and ``xy``.
+    q_best : list
+        Rotations corresponding to each cluster's maximum.
+    order : ndarray
+        Indices that sort clusters by descending ``MaxVal``.
+    xy : ndarray
+        ``(N, 2)`` array of peak coordinates for each cluster.
+    """
+    bw = image > threshold
+    labeled, num = ndimage.label(bw)
+    if num == 0:
+        return [], [], np.array([], dtype=int), np.empty((0, 2), dtype=int)
+
+    objects = ndimage.find_objects(labeled)
+    clusters = []
+    q_best = []
+    xy = []
+    peak_vals = []
+
+    for lbl, sl in enumerate(objects, start=1):
+        region_mask = labeled[sl] == lbl
+        values = image[sl][region_mask]
+        if values.size == 0:
+            continue
+        coords = np.argwhere(region_mask)
+        coords[:, 0] += sl[0].start
+        coords[:, 1] += sl[1].start
+        max_idx = np.argmax(values)
+        max_val = values[max_idx]
+        max_coord = coords[max_idx]
+        clusters.append(
+            {
+                "Area": int(values.size),
+                "PixelList": coords,
+                "MaxVal": float(max_val),
+                "xy": tuple(max_coord),
+            }
+        )
+        idx_rot = int(index_image[tuple(max_coord)])
+        q_best.append(rotations[idx_rot])
+        xy.append(max_coord)
+        peak_vals.append(max_val)
+
+    order = np.argsort(peak_vals)[::-1]
+    clusters = [clusters[i] for i in order]
+    q_best = [q_best[i] for i in order]
+    xy = np.array([xy[i] for i in order], dtype=int)
+    return clusters, q_best, order, xy

--- a/src/smap_tools_python/crop_patch.py
+++ b/src/smap_tools_python/crop_patch.py
@@ -1,0 +1,38 @@
+import numpy as np
+from .phase_shift import apply_phase_shifts
+from .crop_pad import cutj
+
+
+def crop_patch_from_image(arr, half_dim, row_col_inds):
+    """Extract a square patch centered at ``row_col_inds``.
+
+    The patch is taken from ``arr`` by first shifting the image so that the
+    pixel specified by ``row_col_inds`` moves to the image centre, then cropping
+    a region of size ``(2*half_dim, 2*half_dim)`` around the centre.  Indices are
+    zero-based.
+
+    Parameters
+    ----------
+    arr : array_like
+        Input 2-D image.
+    half_dim : int
+        Half the side length of the desired patch. The output patch will be of
+        size ``2*half_dim``.
+    row_col_inds : tuple of int
+        Row and column index of the pixel that should be moved to the centre
+        before cropping.
+
+    Returns
+    -------
+    numpy.ndarray
+        Extracted image patch.
+    """
+    arr = np.asarray(arr)
+    center = np.array(arr.shape[:2]) // 2
+    shifts = center - np.asarray(row_col_inds, dtype=float)
+    shifted = apply_phase_shifts(arr, shifts)
+    if np.isrealobj(arr):
+        shifted = shifted.real
+    size = int(half_dim) * 2
+    patch = cutj(shifted, (size, size))
+    return patch

--- a/src/smap_tools_python/dust.py
+++ b/src/smap_tools_python/dust.py
@@ -1,0 +1,39 @@
+import numpy as np
+from scipy import ndimage
+
+
+def dust(volume, criteria):
+    """Remove small high-valued specks ("dust") from a volume.
+
+    Parameters
+    ----------
+    volume : ndarray
+        Input 3-D volume.
+    criteria : sequence of two numbers
+        ``(threshold, min_size)`` where ``threshold`` is the number of
+        standard deviations above the mean to keep and ``min_size`` is the
+        minimum bounding-box edge length for a region to be retained.
+
+    Returns
+    -------
+    ndarray
+        Volume with small specks suppressed.
+    """
+    volume = np.asarray(volume, dtype=float)
+    thr, dust_size = criteria
+    norm = (volume - np.nanmean(volume)) / np.nanstd(volume)
+    mask = norm > thr
+    labeled, num = ndimage.label(mask)
+    if num == 0:
+        return volume
+    objects = ndimage.find_objects(labeled)
+    out = volume.copy()
+    replace_val = volume.mean() - 2 * volume.std()
+    for i, sl in enumerate(objects, start=1):
+        region = (labeled[sl] == i)
+        bbox = [s.stop - s.start for s in sl]
+        if max(bbox) < dust_size:
+            sub = out[sl]
+            sub[region] = replace_val
+            out[sl] = sub
+    return out

--- a/src/smap_tools_python/pdb.py
+++ b/src/smap_tools_python/pdb.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import numpy as np
+from typing import Dict, List, Any
+
+
+def read_pdb_file(filename: str) -> Dict[str, Any]:
+    """Read an ASCII ``.pdb`` file.
+
+    This is a lightweight parser that extracts atom records and a handful of
+    commonly used fields.  The return value mirrors MATLAB's ``read_pdb_file``
+    helper and provides a dictionary containing atom coordinates and assorted
+    metadata.
+    """
+    with open(filename, "r") as fh:
+        split_lines = fh.read().splitlines()
+
+    atom_list: List[str] = []
+    b_factor: List[float] = []
+    chain_ids: List[str] = []
+    res_name: List[str] = []
+    occ: List[float] = []
+    inds: List[int] = []
+    header: List[str] = []
+    header_inds: List[int] = []
+    line_type: List[int] = []
+    xyz: List[List[float]] = []
+
+    pdb_data = {
+        "atomType": [],
+        "atomNum": [],
+        "atomName": [],
+        "resName": [],
+        "chain": [],
+        "resNum": [],
+        "X": [],
+        "Y": [],
+        "Z": [],
+        "b_factor": [],
+        "comment": [],
+        "filler": [],
+        "occ": [],
+        "line": split_lines,
+    }
+
+    for idx, line in enumerate(split_lines, start=1):
+        record = line[0:6].strip()
+        if record in {"ATOM", "HETATM", "TER"}:
+            try:
+                pdb_data["atomType"].append(line[0:6])
+                pdb_data["atomNum"].append(line[6:11])
+                pdb_data["atomName"].append(line[12:16])
+                pdb_data["resName"].append(line[17:20])
+                pdb_data["chain"].append(line[21:22])
+                pdb_data["resNum"].append(line[22:26])
+                pdb_data["filler"].append(line[27:30])
+                pdb_data["X"].append(line[30:38])
+                pdb_data["Y"].append(line[38:46])
+                pdb_data["Z"].append(line[46:54])
+                pdb_data["occ"].append(line[54:60])
+                pdb_data["b_factor"].append(line[60:66])
+                pdb_data["comment"].append(line[66:])
+
+                x = float(line[30:38])
+                y = float(line[38:46])
+                z = float(line[46:54])
+                xyz.append([x, y, z])
+                atom_list.append(line[12:16].strip())
+                chain_ids.append(line[21:22].strip())
+                res_name.append(line[17:20].strip())
+                b_factor.append(float(line[60:66]))
+                occ.append(float(line[54:60]))
+                inds.append(idx)
+                line_type.append(1)
+            except ValueError:
+                header.append(line)
+                header_inds.append(idx)
+                line_type.append(0)
+        else:
+            header.append(line)
+            header_inds.append(idx)
+            line_type.append(0)
+
+    xyz_arr = np.asarray(xyz, dtype=float).T if xyz else np.empty((3, 0))
+    b_factor_arr = np.asarray(b_factor, dtype=float)
+    occ_arr = np.asarray(occ, dtype=float)
+
+    return {
+        "xyz": xyz_arr,
+        "atomList": atom_list,
+        "bFactor": b_factor_arr,
+        "chainIDs": chain_ids,
+        "resName": res_name,
+        "occ": occ_arr,
+        "inds": inds,
+        "header": header,
+        "headerInds": header_inds,
+        "lineType": line_type,
+        "PDBdata": pdb_data,
+        "splitLines": split_lines,
+    }

--- a/src/smap_tools_python/phase_shift.py
+++ b/src/smap_tools_python/phase_shift.py
@@ -1,0 +1,27 @@
+import numpy as np
+from numpy.fft import fftn, ifftn
+from scipy.ndimage import fourier_shift
+
+
+def apply_phase_shifts(arr, shifts):
+    """Shift an array by subpixel amounts using Fourier phase shifts.
+
+    Parameters
+    ----------
+    arr : array_like
+        Input array to shift. Can be N-dimensional.
+    shifts : array_like
+        Sequence of length ``arr.ndim`` giving shifts along each axis in
+        pixels. Positive values shift toward higher indices.
+
+    Returns
+    -------
+    numpy.ndarray
+        The shifted array, potentially complex when subpixel shifts are used.
+    """
+    arr = np.asarray(arr)
+    shifts = np.asarray(shifts, dtype=float)
+    if shifts.shape != (arr.ndim,):
+        raise ValueError("shifts must match the number of array dimensions")
+    shifted_fft = fourier_shift(fftn(arr), shifts)
+    return ifftn(shifted_fft)

--- a/src/smap_tools_python/polar_image.py
+++ b/src/smap_tools_python/polar_image.py
@@ -1,0 +1,83 @@
+"""Convert an image to log-polar coordinates.
+
+This module provides a translation of SMAP's ``polarImage`` MATLAB
+utility. It maps a 2-D Cartesian image into a log-radius / angle grid
+using spline interpolation from :mod:`scipy.ndimage`.
+"""
+from __future__ import annotations
+
+import numpy as np
+from scipy.ndimage import map_coordinates
+
+
+def polar_image(
+    image: np.ndarray,
+    n_rho: int,
+    n_theta: int,
+    method: str = "linear",
+    center: tuple[float, float] | None = None,
+    shape: str = "full",
+) -> tuple[np.ndarray, np.ndarray]:
+    """Warp ``image`` into log-polar coordinates.
+
+    Parameters
+    ----------
+    image : ndarray
+        Input 2-D array.
+    n_rho : int
+        Number of radial samples.
+    n_theta : int
+        Number of angular samples.
+    method : {"nearest", "linear", "bicubic"}, optional
+        Interpolation method. Defaults to ``"linear"``.
+    center : tuple of float, optional
+        ``(x, y)`` coordinates of the origin. Defaults to the image centre.
+    shape : {"full", "valid"}, optional
+        Behaviour for determining the maximum radius. ``"full"`` uses the
+        distance to the farthest corner whereas ``"valid"`` uses the distance
+        to the nearest edge. Defaults to ``"full"``.
+
+    Returns
+    -------
+    polar : ndarray
+        Polar representation with shape ``(n_rho, n_theta)``.
+    rho : ndarray
+        Radial coordinates corresponding to the rows of ``polar``.
+    """
+
+    image = np.asarray(image, dtype=float)
+    ar, ac = image.shape
+    if center is None:
+        center = ((ac - 1) / 2.0, (ar - 1) / 2.0)
+    cx, cy = center
+
+    theta = np.linspace(0, 2 * np.pi, n_theta, endpoint=False)
+    if shape == "full":
+        corners = np.array([[0, 0], [ac - 1, 0], [ac - 1, ar - 1], [0, ar - 1]], dtype=float)
+        d = np.max(np.sqrt(((corners - (cx, cy)) ** 2).sum(axis=1)))
+    elif shape == "valid":
+        d = min(cx, ac - 1 - cx, cy, ar - 1 - cy)
+    else:  # pragma: no cover - defensive programming
+        raise ValueError("shape must be 'full' or 'valid'")
+
+    rho = np.logspace(np.log10(1.0), np.log10(d), n_rho)
+
+    rr = rho[:, None]
+    tt = theta[None, :]
+    xx = rr * np.cos(tt) + cx
+    yy = rr * np.sin(tt) + cy
+
+    orders = {"nearest": 0, "linear": 1, "bicubic": 3}
+    order = orders.get(method.lower())
+    if order is None:  # pragma: no cover - handled by tests
+        raise ValueError(f"Unknown interpolation method: {method}")
+
+    coords = np.vstack([yy.ravel(), xx.ravel()])
+    polar = map_coordinates(
+        image,
+        coords,
+        order=order,
+        mode="constant",
+        cval=0.0,
+    ).reshape(n_rho, n_theta)
+    return polar, rho

--- a/src/smap_tools_python/r_theta.py
+++ b/src/smap_tools_python/r_theta.py
@@ -1,0 +1,56 @@
+"""Compute an image's mean intensity in ``(r, \theta)`` bins."""
+from __future__ import annotations
+
+import numpy as np
+
+from .nm import nm
+
+
+def r_theta(image: np.ndarray, n_theta: int = 360) -> np.ndarray:
+    """Bin ``image`` into radius/angle coordinates.
+
+    This function mirrors SMAP's MATLAB ``rTheta`` helper but performs all
+    operations with vectorized NumPy calls rather than explicit loops.
+
+    Parameters
+    ----------
+    image : ndarray
+        Input square image.
+    n_theta : int, optional
+        Number of angular bins. Default is 360.
+
+    Returns
+    -------
+    out : ndarray
+        Array of shape ``(n_theta, n_r)`` containing the mean intensity of
+        ``image`` within each ``(r, \theta)`` bin. ``n_r`` depends on the
+        image size.
+    """
+
+    image = np.asarray(image, dtype=float)
+    if image.ndim != 2 or image.shape[0] != image.shape[1]:
+        raise ValueError("image must be square")
+    N = image.shape[0]
+
+    y, x = np.indices(image.shape)
+    cx = cy = N // 2
+    x = x - cx
+    y = cy - y  # MATLAB uses a flipped Y axis
+
+    r_coord = np.hypot(x, y)
+    t_coord = np.mod(np.arctan2(y, x), 2 * np.pi)
+
+    if N % 2:
+        r_bins = np.linspace(0, np.sqrt(2) / 2, int(N * np.sqrt(2) / 2) + 1)
+    else:
+        r_bins = np.linspace(0, np.sqrt(2) / 2, int((N + 1) * np.sqrt(2) / 2) + 1)[:-1]
+    r_bins *= N
+    t_bins = np.linspace(0, 2 * np.pi, n_theta + 1)
+
+    sums, _, _ = np.histogram2d(t_coord.ravel(), r_coord.ravel(), bins=[t_bins, r_bins], weights=image.ravel())
+    counts, _, _ = np.histogram2d(t_coord.ravel(), r_coord.ravel(), bins=[t_bins, r_bins])
+    with np.errstate(invalid="ignore"):
+        out = sums / counts
+    mean_val = np.nanmean(out)
+    out = np.where(np.isnan(out), mean_val, out)
+    return nm(out)

--- a/src/smap_tools_python/ri.py
+++ b/src/smap_tools_python/ri.py
@@ -1,0 +1,73 @@
+"""Image reading utilities translating MATLAB's ``ri`` and ``tr`` helpers."""
+from __future__ import annotations
+
+from pathlib import Path
+import numpy as np
+
+from .mrc import read_mrc
+
+try:  # pragma: no cover - optional dependency
+    import tifffile
+except Exception:  # pragma: no cover
+    tifffile = None
+
+
+def tr(filename: str | Path):
+    """Read a TIFF file returning an array shaped ``(H, W, N)``.
+
+    Parameters
+    ----------
+    filename : str or pathlib.Path
+        Path to the TIFF file.  If no extension is provided ``.tif`` is
+        appended automatically.
+
+    Returns
+    -------
+    numpy.ndarray
+        Image data with the frame axis last, matching the MATLAB ``tr``
+        helper.  Single-frame images retain a third axis of length one.
+    """
+
+    if tifffile is None:  # pragma: no cover
+        raise ImportError("tifffile is required to read TIFF files")
+
+    path = Path(filename)
+    if path.suffix == "":
+        path = path.with_suffix(".tif")
+
+    arr = tifffile.imread(str(path))
+    if arr.ndim == 2:
+        arr = arr[..., np.newaxis]
+    else:
+        arr = np.moveaxis(arr, 0, -1)
+    return arr
+
+
+def ri(filename: str | Path):
+    """Read an image or volume in TIFF or MRC format.
+
+    Parameters
+    ----------
+    filename : str or pathlib.Path
+        Input file path.
+
+    Returns
+    -------
+    tuple
+        ``(data, info)`` where ``info`` is a dictionary that may contain
+        ``"voxel_size"`` for MRC files.  For TIFF files the dictionary is
+        empty.
+    """
+
+    path = Path(filename)
+    ext = path.suffix.lower()
+
+    if ext in (".tif", ".tiff", ""):
+        data = tr(path)
+        return data, {}
+    if ext == ".mrc":
+        data, voxel = read_mrc(str(path))
+        return data, {"voxel_size": voxel}
+    if ext == ".dm4":  # pragma: no cover - not yet implemented
+        raise NotImplementedError("DM4 reading not implemented")
+    raise ValueError(f"Unknown file type: {ext}")

--- a/src/smap_tools_python/tile_images.py
+++ b/src/smap_tools_python/tile_images.py
@@ -1,0 +1,35 @@
+import numpy as np
+
+
+def tile_images(images):
+    """Compose a tiled image from three projections.
+
+    Parameters
+    ----------
+    images : sequence or array
+        Either a list of three 2‑D arrays or a 3‑D array with the third
+        dimension of size three.
+
+    Returns
+    -------
+    numpy.ndarray
+        A ``(2N, 2N)`` tiled image where ``N`` is the edge length of the input
+        images. The bottom-right quadrant is filled with the median of the
+        provided data.
+    """
+    if isinstance(images, np.ndarray):
+        if images.ndim != 3 or images.shape[2] != 3:
+            raise ValueError("expected array of shape (N, N, 3)")
+        proj = [images[:, :, i] for i in range(3)]
+    else:
+        if len(images) != 3:
+            raise ValueError("expected three images")
+        proj = [np.asarray(im) for im in images]
+    n = proj[0].shape[0]
+    out = np.full((2 * n, 2 * n), np.nan, dtype=float)
+    out[0:n, 0:n] = proj[0]
+    out[0:n, n:2 * n] = proj[1]
+    out[n:2 * n, 0:n] = proj[2]
+    median = np.nanmedian(out)
+    out[np.isnan(out)] = median
+    return out

--- a/tests/test_bump_q.py
+++ b/tests/test_bump_q.py
@@ -1,0 +1,36 @@
+import numpy as np
+from smap_tools_python import bump_q, Quaternion
+
+
+def rot_x(a):
+    c, s = np.cos(a), np.sin(a)
+    return np.array([[1, 0, 0], [0, c, -s], [0, s, c]])
+
+
+def rot_z(a):
+    c, s = np.cos(a), np.sin(a)
+    return np.array([[c, -s, 0], [s, c, 0], [0, 0, 1]])
+
+
+def test_bump_q_matrix():
+    Rz = rot_z(np.pi / 2)
+    Rx = rot_x(np.pi / 2)
+    out = bump_q(Rz, Rx)
+    assert out.shape == (3, 3, 1)
+    assert np.allclose(out[:, :, 0], Rx @ Rz)
+
+
+def test_bump_q_quaternion():
+    qin = Quaternion.from_axis_angle([0, 0, 1], np.pi / 2)
+    qbump = Quaternion.from_axis_angle([1, 0, 0], np.pi / 2)
+    out = bump_q(qin, qbump)
+    assert np.allclose(out[:, :, 0], rot_x(np.pi / 2) @ rot_z(np.pi / 2))
+
+
+def test_bump_q_multiple():
+    R_in = np.stack([np.eye(3), rot_z(np.pi / 2)], axis=2)
+    R_bump = np.stack([np.eye(3), rot_x(np.pi / 2)], axis=2)
+    out = bump_q(R_in, R_bump)
+    assert out.shape == (3, 3, 4)
+    assert np.allclose(out[:, :, 0], np.eye(3))
+    assert np.allclose(out[:, :, 3], rot_x(np.pi / 2) @ rot_z(np.pi / 2))

--- a/tests/test_calculate_search_grid.py
+++ b/tests/test_calculate_search_grid.py
@@ -1,0 +1,13 @@
+import numpy as np
+from smap_tools_python import calculate_search_grid
+
+
+def test_calculate_search_grid_c1():
+    RM, EA = calculate_search_grid('C1', 90, 180)
+    assert EA.shape[1] == 14
+    assert RM.shape == (3, 3, 28)
+    assert np.allclose(RM[:, :, 0], np.eye(3))
+    # ensure orthogonality of a sample matrix
+    idx = RM.shape[2] - 1
+    RtR = RM[:, :, idx].T @ RM[:, :, idx]
+    assert np.allclose(RtR, np.eye(3), atol=1e-6)

--- a/tests/test_ccf.py
+++ b/tests/test_ccf.py
@@ -1,0 +1,16 @@
+import numpy as np
+from smap_tools_python import ccf
+
+
+def test_ccf_peak():
+    rng = np.random.default_rng(0)
+    image = rng.normal(size=(8, 8))
+    templates = np.stack([
+        image.copy(),
+        rng.normal(size=(8, 8))
+    ], axis=-1)
+    cc, peaks = ccf(image, templates)
+    assert cc.shape == (8, 8, 2)
+    assert peaks[0] > peaks[1]
+    max_pos = np.unravel_index(np.argmax(cc[:, :, 0]), (8, 8))
+    assert max_pos == (4, 4)

--- a/tests/test_cluster_im_by_thr.py
+++ b/tests/test_cluster_im_by_thr.py
@@ -1,0 +1,27 @@
+import numpy as np
+import numpy as np
+from smap_tools_python import cluster_im_by_thr
+
+
+def test_cluster_im_by_thr_basic():
+    im = np.zeros((5, 5), dtype=float)
+    idx = np.zeros((5, 5), dtype=int)
+    rotations = ['r0', 'r1']
+    # cluster 1
+    im[1, 1] = 1
+    im[1, 2] = 1
+    idx[1, 1] = 0
+    idx[1, 2] = 0
+    # cluster 2 with higher score
+    im[3, 3] = 2
+    im[3, 4] = 2
+    im[4, 3] = 2
+    idx[3, 3] = 1
+    idx[3, 4] = 1
+    idx[4, 3] = 1
+    ss, q_best, order, xy = cluster_im_by_thr(im, idx, 0.5, rotations)
+    assert len(ss) == 2
+    assert np.array_equal(order, [1, 0])
+    assert q_best[0] == 'r1'
+    assert tuple(xy[0]) == ss[0]['xy']
+    assert ss[0]['MaxVal'] == 2

--- a/tests/test_crop_patch.py
+++ b/tests/test_crop_patch.py
@@ -1,0 +1,14 @@
+import numpy as np
+from smap_tools_python.crop_patch import crop_patch_from_image
+
+
+def test_crop_patch_from_image():
+    arr = np.arange(100).reshape(10, 10)
+    half = 2
+    row_col = (2, 7)
+    patch = crop_patch_from_image(arr, half, row_col)
+    center = np.array(arr.shape) // 2
+    shift = center - np.array(row_col)
+    expected_full = np.roll(arr, shift, axis=(0, 1))
+    expected = expected_full[center[0]-half:center[0]+half, center[1]-half:center[1]+half]
+    assert np.allclose(patch, expected)

--- a/tests/test_dust.py
+++ b/tests/test_dust.py
@@ -1,0 +1,11 @@
+import numpy as np
+from smap_tools_python import dust
+
+
+def test_dust_removes_small_cluster():
+    vol = np.zeros((6, 6, 6), dtype=float)
+    vol[1:4, 1:4, 1:4] = 10  # large cluster
+    vol[5, 5, 5] = 10        # tiny dust
+    out = dust(vol, (1, 2))
+    assert out[5, 5, 5] < 5  # dust removed
+    assert out[2, 2, 2] > 5  # large cluster preserved

--- a/tests/test_phase_shift.py
+++ b/tests/test_phase_shift.py
@@ -1,0 +1,18 @@
+import numpy as np
+from smap_tools_python.phase_shift import apply_phase_shifts
+
+
+def test_apply_phase_shifts_integer():
+    arr = np.arange(16).reshape(4, 4)
+    out = apply_phase_shifts(arr, (1, -1))
+    expected = np.roll(arr, (1, -1), axis=(0, 1))
+    assert np.allclose(out, expected)
+
+
+def test_apply_phase_shifts_invertible():
+    rng = np.random.default_rng(0)
+    arr = rng.standard_normal((8, 8))
+    shift = (0.3, -0.7)
+    shifted = apply_phase_shifts(arr, shift)
+    restored = apply_phase_shifts(shifted, (-shift[0], -shift[1]))
+    assert np.allclose(restored, arr)

--- a/tests/test_polar_and_r_theta.py
+++ b/tests/test_polar_and_r_theta.py
@@ -1,0 +1,25 @@
+import numpy as np
+from smap_tools_python import polar_image, r_theta
+
+
+def _radial_image(n):
+    y, x = np.indices((n, n))
+    c = (n - 1) / 2.0
+    return np.hypot(x - c, y - c)
+
+
+def test_polar_image_shape_and_monotonic():
+    img = _radial_image(64)
+    polar, _ = polar_image(img, 32, 90, center=((64 - 1) / 2, (64 - 1) / 2), shape="valid")
+    assert polar.shape == (32, 90)
+    assert np.all(np.diff(polar[:, 0]) >= 0)
+
+
+def test_r_theta_statistics():
+    rng = np.random.default_rng(0)
+    img = rng.standard_normal((64, 64))
+    rt = r_theta(img)
+    assert rt.shape[0] == 360
+    # r_theta normalizes with nm
+    assert abs(rt.mean()) < 1e-6
+    assert abs(rt.std(ddof=1) - 1) < 1e-6

--- a/tests/test_ri.py
+++ b/tests/test_ri.py
@@ -1,0 +1,37 @@
+import numpy as np
+import pytest
+
+mrcfile = pytest.importorskip("mrcfile")
+from smap_tools_python import tr, ri
+
+
+def test_tr_reads_multiframe_tiff(tmp_path):
+    tifffile = pytest.importorskip("tifffile")
+    data = np.arange(12, dtype=np.uint8).reshape(3, 4, 1)
+    data = np.concatenate([data, data + 1], axis=2)
+    path = tmp_path / "test.tif"
+    tifffile.imwrite(str(path), np.moveaxis(data, -1, 0))
+    out = tr(path)
+    assert out.shape == data.shape
+    assert np.all(out == data)
+
+
+def test_ri_handles_mrc(tmp_path):
+    arr = np.arange(8, dtype=np.float32).reshape(2, 2, 2)
+    mrc_path = tmp_path / "vol.mrc"
+    with mrcfile.new(mrc_path, overwrite=True) as mrc:
+        mrc.set_data(arr)
+        mrc.voxel_size = (1.5, 1.5, 1.5)
+    data, info = ri(mrc_path)
+    assert np.allclose(data, arr)
+    assert info["voxel_size"] == (1.5, 1.5, 1.5)
+
+
+def test_ri_handles_tiff(tmp_path):
+    tifffile = pytest.importorskip("tifffile")
+    arr = np.arange(6, dtype=np.uint8).reshape(3, 2)
+    path = tmp_path / "im.tif"
+    tifffile.imwrite(str(path), arr)
+    data, info = ri(path)
+    assert data.shape == (3, 2, 1)
+    assert info == {}

--- a/tests/test_struct_io.py
+++ b/tests/test_struct_io.py
@@ -1,0 +1,30 @@
+import numpy as np
+import pathlib
+
+from smap_tools_python import read_cif_file, read_pdb_file
+
+MODEL_DIR = pathlib.Path(__file__).resolve().parent.parent / "model"
+
+
+def test_read_cif_file_basic():
+    cif_path = MODEL_DIR / "6ek0_LSU.cif"
+    xyz, atom_nums, atom_list, bfac, chains = read_cif_file(str(cif_path), chains=["A"])
+    assert xyz.shape[0] == 3
+    assert len(atom_nums) == xyz.shape[1]
+    assert atom_nums[0] == 1
+    assert atom_list[0] == "C5'"
+    assert chains[0] == "A"
+    assert np.allclose(xyz[:, 0], [-20.637, 30.989, 98.976])
+    assert np.isclose(bfac[0], 109.77)
+
+
+def test_read_pdb_file_basic():
+    pdb_path = MODEL_DIR / "5j5b_monster.pdb"
+    data = read_pdb_file(str(pdb_path))
+    xyz = data["xyz"]
+    assert xyz.shape[0] == 3
+    assert data["atomList"][0] == "N"
+    assert data["chainIDs"][0] == "V"
+    assert np.allclose(xyz[:, 0], [29.342, -33.809, -75.427])
+    assert np.isclose(data["bFactor"][0], 142.22)
+    assert np.isclose(data["occ"][0], 1.00)

--- a/tests/test_tile_images.py
+++ b/tests/test_tile_images.py
@@ -1,0 +1,16 @@
+import numpy as np
+from smap_tools_python.tile_images import tile_images
+
+
+def test_tile_images_basic():
+    im1 = np.array([[1, 2], [3, 4]])
+    im2 = np.array([[5, 6], [7, 8]])
+    im3 = np.array([[9, 10], [11, 12]])
+    out = tile_images([im1, im2, im3])
+    expected = np.array([
+        [1, 2, 5, 6],
+        [3, 4, 7, 8],
+        [9, 10, 6.5, 6.5],
+        [11, 12, 6.5, 6.5],
+    ])
+    assert np.allclose(out, expected)


### PR DESCRIPTION
## Summary
- implement FFT-based `ccf` to correlate images with template stacks
- add 3‑D `dust` filter to suppress small high-valued regions
- introduce `cluster_im_by_thr` and log-polar utilities `polar_image` and `r_theta`
- expose the new helpers through the public package API with tests

## Testing
- `python -m pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68bd7b349fec8328b35da0a5495b4346