### PR TITLE
Add normalize_rm helper and gpuwhos alias

### DIFF
--- a/src/smap_tools_python/__init__.py
+++ b/src/smap_tools_python/__init__.py
@@ -49,7 +49,7 @@ from .parse_cell_array import parse_cell_array
 from .get_psd import get_psd
 from .psd_filter import psd_filter
 from .psd_filter_3d import psd_filter_3d
-from .gpu_whos import gpu_whos
+from .gpu_whos import gpu_whos, gpuwhos
 from .make_filt import make_filt
 from .make_phase_plate import make_phase_plate
 from .assign_jobs import assign_jobs
@@ -58,6 +58,7 @@ from .ts import ts
 from .bump_q import bump_q
 from .calculate_search_grid import calculate_search_grid
 from .measure_qd import measure_qd
+from .normalize_rm import normalize_rm
 from .mw import mw
 from .cif import read_cif_file
 from .pdb import read_pdb_file
@@ -114,6 +115,7 @@ __all__ = [
     "rotate3d_matrix",
     "rot90j",
     "normalize_rotation_matrices",
+    "normalize_rm",
     "radial_mean",
     "radial_average",
     "radial_max",
@@ -140,6 +142,7 @@ __all__ = [
     "approx_mtf",
     "mtf_mm",
     "gpu_whos",
+    "gpuwhos",
     "make_filt",
     "make_phase_plate",
     "assign_jobs",

--- a/src/smap_tools_python/gpu_whos.py
+++ b/src/smap_tools_python/gpu_whos.py
@@ -53,3 +53,7 @@ def gpu_whos(namespace=None):
     if info:
         lines.append(f"total is {total/1e9:6.4f} GB")
     return "\n".join(lines), info, total
+
+# MATLAB compatibility alias
+gpuwhos = gpu_whos
+

--- a/src/smap_tools_python/normalize_rm.py
+++ b/src/smap_tools_python/normalize_rm.py
@@ -1,0 +1,20 @@
+import numpy as np
+from .rotate import normalize_rotation_matrices
+
+
+def normalize_rm(R):
+    """Normalize rotation matrices to be orthonormal with det=+1.
+
+    This is a light-weight wrapper around :func:`normalize_rotation_matrices`
+    to mirror MATLAB's ``normalizeRM`` helper.  The input may be a single
+    3×3 matrix, an ``(N,3,3)`` stack, or a ``(3,3,N)`` stack.
+    """
+    arr = np.asarray(R, dtype=float)
+    if arr.ndim == 2:
+        return normalize_rotation_matrices(arr)
+    if arr.shape[:2] == (3, 3):
+        arr_t = arr.transpose(2, 0, 1)
+        return normalize_rotation_matrices(arr_t).transpose(1, 2, 0)
+    if arr.shape[-2:] == (3, 3):
+        return normalize_rotation_matrices(arr)
+    raise ValueError("Input must be a 3x3 matrix or stack of such matrices")

--- a/tests/test_normalize_rm.py
+++ b/tests/test_normalize_rm.py
@@ -1,0 +1,21 @@
+import numpy as np
+from smap_tools_python import normalize_rm
+
+
+def test_normalize_rm_single():
+    R = np.array([[0, -1, 0], [1, 0, 0], [0, 0, 1]], dtype=float)
+    R_noisy = R + 0.01 * np.eye(3)
+    Rn = normalize_rm(R_noisy)
+    assert np.allclose(Rn @ Rn.T, np.eye(3), atol=1e-6)
+    assert np.isclose(np.linalg.det(Rn), 1.0, atol=1e-6)
+
+
+def test_normalize_rm_stack():
+    R = np.eye(3)
+    stack = np.stack([R + 0.01 * np.eye(3), R - 0.02 * np.eye(3)], axis=2)
+    Rn = normalize_rm(stack)
+    assert Rn.shape == stack.shape
+    for i in range(Rn.shape[2]):
+        Ri = Rn[:, :, i]
+        assert np.allclose(Ri @ Ri.T, np.eye(3), atol=1e-6)
+        assert np.isclose(np.linalg.det(Ri), 1.0, atol=1e-6)


### PR DESCRIPTION
## Summary
- expose a normalize_rm wrapper for orthonormalizing rotation matrices
- add MATLAB-compatible `gpuwhos` alias
- test `normalize_rm` functionality

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68bdc1c4f6b883288b0721fccfbe0ae6