### PR TITLE
Add lb_bh_to_rrs and dw utilities

### DIFF
--- a/src/smap_tools_python/__init__.py
+++ b/src/smap_tools_python/__init__.py
@@ -49,7 +49,7 @@ from .parse_cell_array import parse_cell_array
 from .get_psd import get_psd
 from .psd_filter import psd_filter
 from .psd_filter_3d import psd_filter_3d
-from .gpu_whos import gpu_whos
+from .gpu_whos import gpu_whos, gpuwhos
 from .make_filt import make_filt
 from .make_phase_plate import make_phase_plate
 from .assign_jobs import assign_jobs
@@ -58,6 +58,7 @@ from .ts import ts
 from .bump_q import bump_q
 from .calculate_search_grid import calculate_search_grid
 from .measure_qd import measure_qd
+from .normalize_rm import normalize_rm
 from .mw import mw
 from .cif import read_cif_file
 from .pdb import read_pdb_file
@@ -83,6 +84,8 @@ from .plot_shh import plot_shh
 from .q_fig import q_fig
 from .read_params_file import read_params_file
 from .p3d import p3d
+from .dw import dw
+from .lb_bh_to_rrs import lb_bh_to_rrs
 from .reg2vols import reg2vols
 from .subtract_volume import subtract_volume
 
@@ -114,6 +117,7 @@ __all__ = [
     "rotate3d_matrix",
     "rot90j",
     "normalize_rotation_matrices",
+    "normalize_rm",
     "radial_mean",
     "radial_average",
     "radial_max",
@@ -140,6 +144,7 @@ __all__ = [
     "approx_mtf",
     "mtf_mm",
     "gpu_whos",
+    "gpuwhos",
     "make_filt",
     "make_phase_plate",
     "assign_jobs",
@@ -162,6 +167,8 @@ __all__ = [
     "p3do",
     "p3a",
     "p3d",
+    "dw",
+    "lb_bh_to_rrs",
     "check_base_dir",
     "gridded_qs",
     "pairwise_qd",

--- a/src/smap_tools_python/dw.py
+++ b/src/smap_tools_python/dw.py
@@ -1,0 +1,14 @@
+"""MATLAB-style ``dw`` helper for writing binary volumes."""
+
+from .dat_io import write_dat
+
+
+def dw(array, filename):
+    """Write ``array`` to ``filename`` as a ``.dat`` with header.
+
+    This is a thin wrapper around :func:`write_dat` to mirror MATLAB's
+    ``dw`` utility.  The data are stored as 32-bit floats and a companion
+    ``.hdr`` file records the array shape separated by tabs.
+    """
+
+    write_dat(array, filename)

--- a/src/smap_tools_python/gpu_whos.py
+++ b/src/smap_tools_python/gpu_whos.py
@@ -53,3 +53,7 @@ def gpu_whos(namespace=None):
     if info:
         lines.append(f"total is {total/1e9:6.4f} GB")
     return "\n".join(lines), info, total
+
+# MATLAB compatibility alias
+gpuwhos = gpu_whos
+

--- a/src/smap_tools_python/lb_bh_to_rrs.py
+++ b/src/smap_tools_python/lb_bh_to_rrs.py
@@ -1,0 +1,56 @@
+"""Convert Lab/Beam and Body/Head rotations to RRS coordinates."""
+
+import numpy as np
+from scipy.spatial.transform import Rotation as R
+
+
+def lb_bh_to_rrs(q_lb, q_bh, coeff_b, mu_b, coeff_h, mu_h):
+    """Map rotation matrices to reduced rotation space (RRS).
+
+    Parameters
+    ----------
+    q_lb : array_like, shape (N, 3, 3) or (3, 3, N)
+        Rotation matrices in the lab-to-beam frame.
+    q_bh : array_like, shape (N, 3, 3) or (3, 3, N)
+        Rotation matrices in the body-to-head frame.
+    coeff_b, coeff_h : array_like, shape (3, 3)
+        PCA coefficient matrices for the two frames.
+    mu_b, mu_h : array_like, shape (3,)
+        Mean rotation vectors for the two frames.
+
+    Returns
+    -------
+    ndarray, shape (N, 3)
+        Coordinates in reduced rotation space in degrees.
+    """
+
+    q_lb = np.asarray(q_lb, dtype=float)
+    q_bh = np.asarray(q_bh, dtype=float)
+    coeff_b = np.asarray(coeff_b, dtype=float)
+    coeff_h = np.asarray(coeff_h, dtype=float)
+    mu_b = np.asarray(mu_b, dtype=float)
+    mu_h = np.asarray(mu_h, dtype=float)
+
+    if q_lb.shape[-2:] != (3, 3) or q_bh.shape[-2:] != (3, 3):
+        raise ValueError("Input rotations must have shape (..., 3, 3)")
+
+    # Move rotation index to first dimension if necessary
+    q_lb = np.reshape(q_lb, (-1, 3, 3)) if q_lb.shape[0] != 3 else np.moveaxis(q_lb, -1, 0)
+    q_bh = np.reshape(q_bh, (-1, 3, 3)) if q_bh.shape[0] != 3 else np.moveaxis(q_bh, -1, 0)
+
+    zero_lb = (-mu_b) @ coeff_b
+    zero_bh = (-mu_h) @ coeff_h
+
+    n = q_lb.shape[0]
+    rrs = np.empty((n, 3), dtype=float)
+
+    for i in range(n):
+        rv_lb = R.from_matrix(q_lb[i]).as_rotvec()
+        coords_lb = (rv_lb - mu_b) @ coeff_b - zero_lb
+
+        rv_bh = R.from_matrix(q_bh[i]).as_rotvec()
+        coords_bh = (rv_bh - mu_h) @ coeff_h - zero_bh
+
+        rrs[i] = [coords_lb[0], coords_lb[1], coords_bh[0]]
+
+    return rrs * (-180.0 / np.pi)

--- a/src/smap_tools_python/normalize_rm.py
+++ b/src/smap_tools_python/normalize_rm.py
@@ -1,0 +1,20 @@
+import numpy as np
+from .rotate import normalize_rotation_matrices
+
+
+def normalize_rm(R):
+    """Normalize rotation matrices to be orthonormal with det=+1.
+
+    This is a light-weight wrapper around :func:`normalize_rotation_matrices`
+    to mirror MATLAB's ``normalizeRM`` helper.  The input may be a single
+    3×3 matrix, an ``(N,3,3)`` stack, or a ``(3,3,N)`` stack.
+    """
+    arr = np.asarray(R, dtype=float)
+    if arr.ndim == 2:
+        return normalize_rotation_matrices(arr)
+    if arr.shape[:2] == (3, 3):
+        arr_t = arr.transpose(2, 0, 1)
+        return normalize_rotation_matrices(arr_t).transpose(1, 2, 0)
+    if arr.shape[-2:] == (3, 3):
+        return normalize_rotation_matrices(arr)
+    raise ValueError("Input must be a 3x3 matrix or stack of such matrices")

--- a/tests/test_dw.py
+++ b/tests/test_dw.py
@@ -1,0 +1,12 @@
+import numpy as np
+from smap_tools_python import dw
+
+
+def test_dw_roundtrip(tmp_path):
+    arr = np.arange(12, dtype=np.float32).reshape(3, 4)
+    fn = tmp_path / "out.dat"
+    dw(arr, fn)
+    data = np.fromfile(fn, dtype=np.float32).reshape(arr.shape)
+    assert np.allclose(data, arr)
+    hdr = (tmp_path / "out.hdr").read_text().strip()
+    assert hdr == "3\t4"

--- a/tests/test_lb_bh_to_rrs.py
+++ b/tests/test_lb_bh_to_rrs.py
@@ -1,0 +1,12 @@
+import numpy as np
+from smap_tools_python import lb_bh_to_rrs
+
+
+def test_lb_bh_to_rrs_identity():
+    q_lb = np.eye(3)[None, :, :]
+    q_bh = np.eye(3)[None, :, :]
+    coeff = np.eye(3)
+    mu = np.zeros(3)
+    out = lb_bh_to_rrs(q_lb, q_bh, coeff, mu, coeff, mu)
+    assert out.shape == (1, 3)
+    assert np.allclose(out, 0.0)

--- a/tests/test_normalize_rm.py
+++ b/tests/test_normalize_rm.py
@@ -1,0 +1,21 @@
+import numpy as np
+from smap_tools_python import normalize_rm
+
+
+def test_normalize_rm_single():
+    R = np.array([[0, -1, 0], [1, 0, 0], [0, 0, 1]], dtype=float)
+    R_noisy = R + 0.01 * np.eye(3)
+    Rn = normalize_rm(R_noisy)
+    assert np.allclose(Rn @ Rn.T, np.eye(3), atol=1e-6)
+    assert np.isclose(np.linalg.det(Rn), 1.0, atol=1e-6)
+
+
+def test_normalize_rm_stack():
+    R = np.eye(3)
+    stack = np.stack([R + 0.01 * np.eye(3), R - 0.02 * np.eye(3)], axis=2)
+    Rn = normalize_rm(stack)
+    assert Rn.shape == stack.shape
+    for i in range(Rn.shape[2]):
+        Ri = Rn[:, :, i]
+        assert np.allclose(Ri @ Ri.T, np.eye(3), atol=1e-6)
+        assert np.isclose(np.linalg.det(Ri), 1.0, atol=1e-6)


### PR DESCRIPTION
## Summary
- add dw wrapper mirroring MATLAB helper to write .dat volumes
- implement lb_bh_to_rrs to convert rotation matrices to reduced rotation space
- expose new utilities and corresponding tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68bdc1c4f6b883288b0721fccfbe0ae6