### PR TITLE
Add radial utilities and cosine mask alias

### DIFF
--- a/src/smap_tools_python/__init__.py
+++ b/src/smap_tools_python/__init__.py
@@ -1,6 +1,6 @@
 """Python utilities for SMAP tools."""
 
-from .cos_mask import variable_cos_mask
+from .cos_mask import cos_mask, variable_cos_mask
 from .rrj import rrj
 from .quaternion import Quaternion
 from .constants import def_consts
@@ -24,7 +24,15 @@ from .rotate import (
     rot90j,
     normalize_rotation_matrices,
 )
-from .radial import radial_mean, radial_average, radial_max
+from .radial import (
+    radial_mean,
+    radial_average,
+    radial_max,
+    radialmeanj,
+    radialmean_im,
+    radial_average_im,
+    radialmaxj,
+)
 from .polar_image import polar_image
 from .r_theta import r_theta
 from .g2 import g2
@@ -49,7 +57,7 @@ from .parse_cell_array import parse_cell_array
 from .get_psd import get_psd
 from .psd_filter import psd_filter
 from .psd_filter_3d import psd_filter_3d
-from .gpu_whos import gpu_whos
+from .gpu_whos import gpu_whos, gpuwhos
 from .make_filt import make_filt
 from .make_phase_plate import make_phase_plate
 from .assign_jobs import assign_jobs
@@ -58,6 +66,7 @@ from .ts import ts
 from .bump_q import bump_q
 from .calculate_search_grid import calculate_search_grid
 from .measure_qd import measure_qd
+from .normalize_rm import normalize_rm
 from .mw import mw
 from .cif import read_cif_file
 from .pdb import read_pdb_file
@@ -83,10 +92,13 @@ from .plot_shh import plot_shh
 from .q_fig import q_fig
 from .read_params_file import read_params_file
 from .p3d import p3d
+from .dw import dw
+from .lb_bh_to_rrs import lb_bh_to_rrs
 from .reg2vols import reg2vols
 from .subtract_volume import subtract_volume
 
 __all__ = [
+    "cos_mask",
     "variable_cos_mask",
     "rrj",
     "Quaternion",
@@ -114,9 +126,14 @@ __all__ = [
     "rotate3d_matrix",
     "rot90j",
     "normalize_rotation_matrices",
+    "normalize_rm",
     "radial_mean",
     "radial_average",
     "radial_max",
+    "radialmeanj",
+    "radialmean_im",
+    "radial_average_im",
+    "radialmaxj",
     "polar_image",
     "r_theta",
     "g2",
@@ -140,6 +157,7 @@ __all__ = [
     "approx_mtf",
     "mtf_mm",
     "gpu_whos",
+    "gpuwhos",
     "make_filt",
     "make_phase_plate",
     "assign_jobs",
@@ -162,6 +180,8 @@ __all__ = [
     "p3do",
     "p3a",
     "p3d",
+    "dw",
+    "lb_bh_to_rrs",
     "check_base_dir",
     "gridded_qs",
     "pairwise_qd",

--- a/src/smap_tools_python/cos_mask.py
+++ b/src/smap_tools_python/cos_mask.py
@@ -1,17 +1,48 @@
+"""Cosine-edged radial masks."""
+
+from __future__ import annotations
+
 import numpy as np
+
 from .rrj import rrj
 
 
-def variable_cos_mask(im_size, mask_edges, a_per_pix):
-    """Replicates MATLAB's variableCosMask function."""
+def cos_mask(im_size: int, mask_edges, a_per_pix: float):
+    """Create a cosine-edged circular mask.
+
+    Parameters
+    ----------
+    im_size : int
+        Size of the (square) output mask in pixels.
+    mask_edges : tuple[float, float]
+        Inner and outer radii of the cosine falloff in Å.
+    a_per_pix : float
+        Ångstroms per pixel for the grid.
+
+    Returns
+    -------
+    numpy.ndarray
+        ``im_size`` × ``im_size`` mask with values in ``[0, 1]``.
+    """
+
     mask_edge_in, mask_edge_out = mask_edges
     nn = rrj((im_size, im_size))
     R = nn / a_per_pix
-    Rt = R <= mask_edge_in
-    RR = np.abs(R - mask_edge_in) * (~Rt)
-    Rtt = R > mask_edge_out
-    RR[Rtt] = np.pi / 2
-    T = (mask_edge_in - mask_edge_out) * 2
-    RRR = 0.5 + 0.5 * np.cos(2 * np.pi * RR / T)
-    RRR[Rtt] = 0
-    return RRR
+    inside = R <= mask_edge_in
+    ramp = np.abs(R - mask_edge_in)
+    outside = R > mask_edge_out
+    ramp[outside] = np.pi / 2
+    width = (mask_edge_in - mask_edge_out) * 2
+    mask = 0.5 + 0.5 * np.cos(2 * np.pi * ramp / width)
+    mask[outside] = 0
+    mask[inside] = 1
+    return mask
+
+
+def variable_cos_mask(im_size: int, mask_edges, a_per_pix: float):
+    """Backward-compatible wrapper for MATLAB's ``variableCosMask``."""
+
+    return cos_mask(im_size, mask_edges, a_per_pix)
+
+
+__all__ = ["cos_mask", "variable_cos_mask"]

--- a/src/smap_tools_python/dw.py
+++ b/src/smap_tools_python/dw.py
@@ -1,0 +1,14 @@
+"""MATLAB-style ``dw`` helper for writing binary volumes."""
+
+from .dat_io import write_dat
+
+
+def dw(array, filename):
+    """Write ``array`` to ``filename`` as a ``.dat`` with header.
+
+    This is a thin wrapper around :func:`write_dat` to mirror MATLAB's
+    ``dw`` utility.  The data are stored as 32-bit floats and a companion
+    ``.hdr`` file records the array shape separated by tabs.
+    """
+
+    write_dat(array, filename)

--- a/src/smap_tools_python/gpu_whos.py
+++ b/src/smap_tools_python/gpu_whos.py
@@ -53,3 +53,7 @@ def gpu_whos(namespace=None):
     if info:
         lines.append(f"total is {total/1e9:6.4f} GB")
     return "\n".join(lines), info, total
+
+# MATLAB compatibility alias
+gpuwhos = gpu_whos
+

--- a/src/smap_tools_python/lb_bh_to_rrs.py
+++ b/src/smap_tools_python/lb_bh_to_rrs.py
@@ -1,0 +1,56 @@
+"""Convert Lab/Beam and Body/Head rotations to RRS coordinates."""
+
+import numpy as np
+from scipy.spatial.transform import Rotation as R
+
+
+def lb_bh_to_rrs(q_lb, q_bh, coeff_b, mu_b, coeff_h, mu_h):
+    """Map rotation matrices to reduced rotation space (RRS).
+
+    Parameters
+    ----------
+    q_lb : array_like, shape (N, 3, 3) or (3, 3, N)
+        Rotation matrices in the lab-to-beam frame.
+    q_bh : array_like, shape (N, 3, 3) or (3, 3, N)
+        Rotation matrices in the body-to-head frame.
+    coeff_b, coeff_h : array_like, shape (3, 3)
+        PCA coefficient matrices for the two frames.
+    mu_b, mu_h : array_like, shape (3,)
+        Mean rotation vectors for the two frames.
+
+    Returns
+    -------
+    ndarray, shape (N, 3)
+        Coordinates in reduced rotation space in degrees.
+    """
+
+    q_lb = np.asarray(q_lb, dtype=float)
+    q_bh = np.asarray(q_bh, dtype=float)
+    coeff_b = np.asarray(coeff_b, dtype=float)
+    coeff_h = np.asarray(coeff_h, dtype=float)
+    mu_b = np.asarray(mu_b, dtype=float)
+    mu_h = np.asarray(mu_h, dtype=float)
+
+    if q_lb.shape[-2:] != (3, 3) or q_bh.shape[-2:] != (3, 3):
+        raise ValueError("Input rotations must have shape (..., 3, 3)")
+
+    # Move rotation index to first dimension if necessary
+    q_lb = np.reshape(q_lb, (-1, 3, 3)) if q_lb.shape[0] != 3 else np.moveaxis(q_lb, -1, 0)
+    q_bh = np.reshape(q_bh, (-1, 3, 3)) if q_bh.shape[0] != 3 else np.moveaxis(q_bh, -1, 0)
+
+    zero_lb = (-mu_b) @ coeff_b
+    zero_bh = (-mu_h) @ coeff_h
+
+    n = q_lb.shape[0]
+    rrs = np.empty((n, 3), dtype=float)
+
+    for i in range(n):
+        rv_lb = R.from_matrix(q_lb[i]).as_rotvec()
+        coords_lb = (rv_lb - mu_b) @ coeff_b - zero_lb
+
+        rv_bh = R.from_matrix(q_bh[i]).as_rotvec()
+        coords_bh = (rv_bh - mu_h) @ coeff_h - zero_bh
+
+        rrs[i] = [coords_lb[0], coords_lb[1], coords_bh[0]]
+
+    return rrs * (-180.0 / np.pi)

--- a/src/smap_tools_python/normalize_rm.py
+++ b/src/smap_tools_python/normalize_rm.py
@@ -1,0 +1,20 @@
+import numpy as np
+from .rotate import normalize_rotation_matrices
+
+
+def normalize_rm(R):
+    """Normalize rotation matrices to be orthonormal with det=+1.
+
+    This is a light-weight wrapper around :func:`normalize_rotation_matrices`
+    to mirror MATLAB's ``normalizeRM`` helper.  The input may be a single
+    3×3 matrix, an ``(N,3,3)`` stack, or a ``(3,3,N)`` stack.
+    """
+    arr = np.asarray(R, dtype=float)
+    if arr.ndim == 2:
+        return normalize_rotation_matrices(arr)
+    if arr.shape[:2] == (3, 3):
+        arr_t = arr.transpose(2, 0, 1)
+        return normalize_rotation_matrices(arr_t).transpose(1, 2, 0)
+    if arr.shape[-2:] == (3, 3):
+        return normalize_rotation_matrices(arr)
+    raise ValueError("Input must be a 3x3 matrix or stack of such matrices")

--- a/src/smap_tools_python/radial.py
+++ b/src/smap_tools_python/radial.py
@@ -54,3 +54,74 @@ def radial_max(image: np.ndarray) -> np.ndarray:
         if val > out[rad]:
             out[rad] = val
     return out
+
+
+def radialmeanj(arr: np.ndarray, return_nd: bool = False):
+    """Dimension-agnostic radial mean profile.
+
+    Parameters
+    ----------
+    arr : ndarray
+        Input array, 1-D, 2-D or 3-D.
+    return_nd : bool, optional
+        If ``True`` also return an array where each element is replaced by
+        the mean of all pixels/voxels sharing its rounded radius.
+
+    Returns
+    -------
+    profile : ndarray
+        Radial mean values indexed by integer radius.
+    arr_mean : ndarray, optional
+        Only returned if ``return_nd`` is ``True``.
+    """
+
+    arr = np.asarray(arr, dtype=float)
+    coords = np.meshgrid(*[np.arange(n) for n in arr.shape], indexing="ij")
+    center = [(n - 1) / 2.0 for n in arr.shape]
+    r = np.sqrt(sum((c - ctr) ** 2 for c, ctr in zip(coords, center)))
+    r_int = np.round(r).astype(np.int64)
+
+    sums = np.bincount(r_int.ravel(), weights=arr.ravel())
+    counts = np.bincount(r_int.ravel())
+    counts[counts == 0] = 1
+    profile = sums / counts
+    if return_nd:
+        return profile, profile[r_int]
+    return profile
+
+
+def radialmean_im(image: np.ndarray) -> np.ndarray:
+    """Wrapper mirroring MATLAB's ``radialmeanIm``."""
+
+    return radialmeanj(image)
+
+
+def radial_average_im(image: np.ndarray) -> np.ndarray:
+    """Wrapper mirroring MATLAB's ``radialAverageIm``."""
+
+    _, nd = radialmeanj(image, return_nd=True)
+    return nd
+
+
+def radialmaxj(arr: np.ndarray) -> np.ndarray:
+    """Radial maximum profile for an N‑D array."""
+
+    arr = np.asarray(arr, dtype=float)
+    coords = np.meshgrid(*[np.arange(n) for n in arr.shape], indexing="ij")
+    center = [(n - 1) / 2.0 for n in arr.shape]
+    r = np.sqrt(sum((c - ctr) ** 2 for c, ctr in zip(coords, center)))
+    r_int = np.round(r).astype(np.int64)
+    out = np.full(r_int.max() + 1, -np.inf)
+    np.maximum.at(out, r_int.ravel(), arr.ravel())
+    return out
+
+
+__all__ = [
+    "radial_mean",
+    "radial_average",
+    "radial_max",
+    "radialmeanj",
+    "radialmean_im",
+    "radial_average_im",
+    "radialmaxj",
+]

--- a/tests/test_cos_mask_and_radial.py
+++ b/tests/test_cos_mask_and_radial.py
@@ -1,0 +1,49 @@
+import numpy as np
+
+from smap_tools_python import (
+    cos_mask,
+    variable_cos_mask,
+    radial_mean,
+    radial_average,
+    radial_max,
+    radialmeanj,
+    radialmean_im,
+    radial_average_im,
+    radialmaxj,
+)
+
+
+def test_cos_mask_matches_variable_version():
+    a = cos_mask(8, (2.0, 3.0), 1.0)
+    b = variable_cos_mask(8, (2.0, 3.0), 1.0)
+    assert np.allclose(a, b)
+
+
+def test_radialmeanj_agrees_with_radial_mean():
+    im = np.arange(16, dtype=float).reshape(4, 4)
+    prof = radialmeanj(im)
+    np.testing.assert_allclose(prof[: len(radial_mean(im))], radial_mean(im))
+
+
+def test_radialmeanj_return_nd_and_3d():
+    vol = np.ones((3, 3, 3), dtype=float)
+    vol[1, 1, 1] = 3.0
+    prof, nd = radialmeanj(vol, return_nd=True)
+    assert prof[0] == 3.0
+    assert nd.shape == vol.shape
+    assert nd[1, 1, 1] == 3.0
+
+
+def test_radial_average_im_alias():
+    im = np.arange(16, dtype=float).reshape(4, 4)
+    np.testing.assert_allclose(radial_average_im(im), radial_average(im))
+
+
+def test_radialmean_im_alias():
+    im = np.arange(16, dtype=float).reshape(4, 4)
+    np.testing.assert_allclose(radialmean_im(im), radial_mean(im))
+
+
+def test_radialmaxj_alias():
+    im = np.arange(16, dtype=float).reshape(4, 4)
+    np.testing.assert_allclose(radialmaxj(im), radial_max(im))

--- a/tests/test_dw.py
+++ b/tests/test_dw.py
@@ -1,0 +1,12 @@
+import numpy as np
+from smap_tools_python import dw
+
+
+def test_dw_roundtrip(tmp_path):
+    arr = np.arange(12, dtype=np.float32).reshape(3, 4)
+    fn = tmp_path / "out.dat"
+    dw(arr, fn)
+    data = np.fromfile(fn, dtype=np.float32).reshape(arr.shape)
+    assert np.allclose(data, arr)
+    hdr = (tmp_path / "out.hdr").read_text().strip()
+    assert hdr == "3\t4"

--- a/tests/test_lb_bh_to_rrs.py
+++ b/tests/test_lb_bh_to_rrs.py
@@ -1,0 +1,12 @@
+import numpy as np
+from smap_tools_python import lb_bh_to_rrs
+
+
+def test_lb_bh_to_rrs_identity():
+    q_lb = np.eye(3)[None, :, :]
+    q_bh = np.eye(3)[None, :, :]
+    coeff = np.eye(3)
+    mu = np.zeros(3)
+    out = lb_bh_to_rrs(q_lb, q_bh, coeff, mu, coeff, mu)
+    assert out.shape == (1, 3)
+    assert np.allclose(out, 0.0)

--- a/tests/test_normalize_rm.py
+++ b/tests/test_normalize_rm.py
@@ -1,0 +1,21 @@
+import numpy as np
+from smap_tools_python import normalize_rm
+
+
+def test_normalize_rm_single():
+    R = np.array([[0, -1, 0], [1, 0, 0], [0, 0, 1]], dtype=float)
+    R_noisy = R + 0.01 * np.eye(3)
+    Rn = normalize_rm(R_noisy)
+    assert np.allclose(Rn @ Rn.T, np.eye(3), atol=1e-6)
+    assert np.isclose(np.linalg.det(Rn), 1.0, atol=1e-6)
+
+
+def test_normalize_rm_stack():
+    R = np.eye(3)
+    stack = np.stack([R + 0.01 * np.eye(3), R - 0.02 * np.eye(3)], axis=2)
+    Rn = normalize_rm(stack)
+    assert Rn.shape == stack.shape
+    for i in range(Rn.shape[2]):
+        Ri = Rn[:, :, i]
+        assert np.allclose(Ri @ Ri.T, np.eye(3), atol=1e-6)
+        assert np.isclose(np.linalg.det(Ri), 1.0, atol=1e-6)


### PR DESCRIPTION
## Summary
- provide `cos_mask` wrapper mirroring MATLAB's cosine-edged mask helper
- implement dimension-agnostic radial statistics (`radialmeanj`, `radialmean_im`, `radial_average_im`, `radialmaxj`)
- cover new utilities with tests and export via package init

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68bdc1c4f6b883288b0721fccfbe0ae6