### PR TITLE
Add Python translations for CTFFIND runner and template stack builder

### DIFF
--- a/src/smap_tools_python/__init__.py
+++ b/src/smap_tools_python/__init__.py
@@ -119,6 +119,8 @@ from .smap2cistem import smap2cistem
 from .register_multiple_fragments import register_multiple_fragments
 from .ipcc import ipcc, ipcc_m
 from .write_search_params import write_search_params, writeSearchParams
+from .run_ctffind import run_ctffind
+from .make_template_stack import make_template_stack
 
 
 quaternion = Quaternion
@@ -251,6 +253,8 @@ __all__ = [
     "getDataset",
     "getDatasets",
     "putDataset",
+    "run_ctffind",
+    "make_template_stack",
     "smap2pymol",
     "smap2frealign",
     "smap2cistem",

--- a/src/smap_tools_python/make_template_stack.py
+++ b/src/smap_tools_python/make_template_stack.py
@@ -1,0 +1,52 @@
+import numpy as np
+from .ccf import ccf
+from .max_interp_f import max_interp_f
+from .phase_shift import apply_phase_shifts
+from .crop_pad import extendj, cutj
+
+
+def make_template_stack(nf_im, templates=None, ref_template_stack=None):
+    """Align templates to an image and return their stack and sum.
+
+    Parameters
+    ----------
+    nf_im : ndarray
+        The noise-filtered image used for alignment.
+    templates : ndarray, optional
+        Stack of templates with shape ``(M, N, K)``.
+    ref_template_stack : ndarray, optional
+        Reference stack to provide initial alignment coordinates.
+
+    Returns
+    -------
+    tuple of (ndarray, ndarray)
+        ``ti`` is the summed template image and ``template_im`` contains the
+        individual aligned templates.
+    """
+    nf_im = np.asarray(nf_im, dtype=float)
+    if templates is None:
+        return np.zeros_like(nf_im), np.zeros(nf_im.shape + (0,), dtype=float)
+
+    templates = np.asarray(templates, dtype=float)
+    pad_val = np.nanmedian(templates)
+    ti = np.ones_like(nf_im, dtype=float) * pad_val
+    template_im = np.ones(nf_im.shape + (templates.shape[2],), dtype=float) * pad_val
+
+    for j in range(templates.shape[2]):
+        temp = templates[:, :, j]
+        if ref_template_stack is None:
+            cc, _ = ccf(nf_im, temp[:, :, None])
+            cc = cc[:, :, 0]
+        else:
+            cc, _ = ccf(nf_im, ref_template_stack[:, :, j][:, :, None])
+            cc = cc[:, :, 0]
+        yt, xt = np.unravel_index(np.argmax(cc), cc.shape)
+        shifts, _ = max_interp_f(cc, 10, 20, (yt, xt))
+        padded = extendj(temp, (2048, 2048), pad_val)
+        shifted = apply_phase_shifts(padded, shifts)
+        template_im[:, :, j] = cutj(shifted, (nf_im.shape[0], nf_im.shape[1]))
+        ti += template_im[:, :, j]
+
+    return ti, template_im
+
+__all__ = ["make_template_stack"]

--- a/src/smap_tools_python/run_ctffind.py
+++ b/src/smap_tools_python/run_ctffind.py
@@ -1,0 +1,45 @@
+import subprocess
+from pathlib import Path
+
+
+def run_ctffind(obj):
+    """Run the external *ctffind* program using parameters from ``obj``.
+
+    The input ``obj`` is expected to be a mapping or object with ``CTF`` and
+    ``proc`` attributes/keys mirroring the MATLAB structure. The function writes
+    the parameter file, executes ``ctffind`` and parses the diagnostic output to
+    populate ``obj['final']`` and ``obj['ID']`` entries.
+    """
+    # support both attribute and dict style access
+    ctf_params = getattr(obj, "CTF", obj["CTF"])
+    proc = getattr(obj, "proc", obj["proc"])
+    out = getattr(obj, "final", obj.setdefault("final", {}))
+    ident = getattr(obj, "ID", obj.setdefault("ID", {}))
+
+    # write the parameter file expected by ctffind
+    params = {}
+    for key, val in ctf_params.items():
+        params[key] = str(val)
+    base = Path(proc["fullSum_image"])
+    fn_out = base.with_name(base.stem + "_CTFFind_input.txt")
+    with open(fn_out, "w") as fh:
+        for k, v in params.items():
+            fh.write(f"{k} {v}\n")
+
+    # execute ctffind
+    subprocess.run(["ctffind", str(fn_out)], check=True)
+
+    # read diagnostic output
+    diag_base = Path(ctf_params["output_diag_filename"])
+    diag_fn = diag_base.with_suffix(".txt")
+    with open(diag_fn, "r") as fh:
+        lines = fh.readlines()[5:12]
+    vals = [float(line.split()[0]) for line in lines[:7]]
+
+    out["df1"] = vals[1] / 10.0
+    out["df2"] = vals[2] / 10.0
+    out["ast"] = vals[3] * 3.141592653589793 / 180.0
+    ident["CTF"] = 1
+    return obj
+
+__all__ = ["run_ctffind"]


### PR DESCRIPTION
## Summary
- implement `run_ctffind` to execute CTFFIND using SMAP-style objects
- add `make_template_stack` for aligning and summing templates
- export new utilities in `smap_tools_python`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68bdd8f30abc832899b53a9bac9d5645