### PR TITLE
Add DM reader, CTFFIND, dose handling, and cross-correlation utilities

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ scipy
 pytest
 mrcfile
 openpyxl
+ncempy

--- a/src/smap_tools_python/__init__.py
+++ b/src/smap_tools_python/__init__.py
@@ -44,6 +44,7 @@ from .getcp import get_center_pixel, getcp
 from .mrc import read_mrc, write_mrc
 from .mr import mr
 from .ri import tr, ri, tw
+from .read_dm_file import read_dm_file
 from .bindata import bindata
 from .particle_diameter import particle_diameter
 from .resize_f import resize_F
@@ -74,6 +75,8 @@ from .mw import mw
 from .cif import read_cif_file
 from .pdb import read_pdb_file
 from .ccf import ccf
+from .ccfn import ccfn
+from .ccfv import ccfv
 from .cluster_im_by_thr import cluster_im_by_thr
 from .dust import dust
 from .proj_view import proj_view
@@ -119,6 +122,10 @@ from .smap2cistem import smap2cistem
 from .register_multiple_fragments import register_multiple_fragments
 from .ipcc import ipcc, ipcc_m
 from .write_search_params import write_search_params, writeSearchParams
+from .run_ctffind import run_ctffind
+from .make_template_stack import make_template_stack
+from .write_mrc_header import write_mrc_header
+from .dose_filter import dose_filter
 
 
 quaternion = Quaternion
@@ -203,6 +210,8 @@ __all__ = [
     "read_cif_file",
     "read_pdb_file",
     "ccf",
+    "ccfn",
+    "ccfv",
     "cluster_im_by_thr",
     "dust",
     "proj_view",
@@ -251,6 +260,10 @@ __all__ = [
     "getDataset",
     "getDatasets",
     "putDataset",
+    "run_ctffind",
+    "make_template_stack",
+    "write_mrc_header",
+    "dose_filter",
     "smap2pymol",
     "smap2frealign",
     "smap2cistem",

--- a/src/smap_tools_python/ccfn.py
+++ b/src/smap_tools_python/ccfn.py
@@ -1,0 +1,62 @@
+import numpy as np
+from .crop_pad import crop_or_pad
+from .radial import radial_average_im
+
+
+def ccfn(image, templates):
+    """Frequency-normalized cross-correlation.
+
+    Parameters
+    ----------
+    image : ndarray, shape (M, N)
+        Input 2D image.
+    templates : ndarray, shape (M_t, N_t, K)
+        Stack of ``K`` templates.
+
+    Returns
+    -------
+    tuple of (ndarray, ndarray)
+        ``cc`` is the cross-correlation volume of shape ``(M, N, K)`` and
+        ``peaks`` holds the maximum value for each template.
+    """
+    image = np.asarray(image, dtype=float)
+    templates = np.asarray(templates, dtype=float)
+    if image.ndim != 2 or templates.ndim != 3:
+        raise ValueError("image must be 2D and templates 3D")
+
+    full_x, full_y = image.shape
+    full_xy = full_x * full_y
+    cp = full_x // 2
+
+    # Zero-mean image and estimate power spectral density via radial averaging
+    image = image - image.mean()
+    f_amp = np.abs(np.fft.fftshift(np.fft.fftn(np.fft.ifftshift(image)))) / full_x
+    f_amp_r = radial_average_im(f_amp)
+    f_amp_r[cp, cp] = 1.0
+    f_amp_r_inv = 1.0 / f_amp_r
+    f_amp_r_inv[cp, cp] = np.nan
+    f_amp_r_inv[cp, cp] = np.nanmean(
+        f_amp_r_inv[cp - 1 : cp + 2, cp - 1 : cp + 2]
+    )
+    f_psd = (f_amp_r_inv / np.sum(np.abs(f_amp_r_inv.ravel()) ** 2)) * (full_x ** 2)
+    f_psd = np.fft.ifftshift(f_psd)
+
+    image_f = np.fft.fftn(np.fft.ifftshift(image)) * f_psd
+    v = np.sum(np.abs(image_f.ravel()) ** 2) / full_xy
+    denom = np.sqrt(v / full_xy)
+    image_f /= denom
+
+    n_templates = templates.shape[2]
+    out = np.empty((full_x, full_y, n_templates), dtype=float)
+    peaks = np.empty(n_templates, dtype=float)
+
+    for i in range(n_templates):
+        temp = templates[:, :, i]
+        temp = temp - temp.mean()
+        template = crop_or_pad(temp, image.shape, pad_value=0)
+        template_f = np.fft.fftn(np.fft.ifftshift(template)) * f_psd
+        cc_f = image_f * np.conj(template_f)
+        temp_cc = np.real(np.fft.fftshift(np.fft.ifftn(cc_f)))
+        out[:, :, i] = temp_cc
+        peaks[i] = temp_cc.max()
+    return out, peaks

--- a/src/smap_tools_python/ccfv.py
+++ b/src/smap_tools_python/ccfv.py
@@ -1,0 +1,48 @@
+import numpy as np
+from .crop_pad import crop_or_pad
+
+
+def ccfv(image, templates):
+    """Variance-normalized cross-correlation.
+
+    Parameters
+    ----------
+    image : ndarray, shape (M, N)
+        Input 2D image.
+    templates : ndarray, shape (M_t, N_t, K)
+        Stack of ``K`` templates.
+
+    Returns
+    -------
+    tuple of (ndarray, ndarray)
+        ``cc`` is the cross-correlation volume of shape ``(M, N, K)`` and
+        ``peaks`` holds the maximum value for each template.
+    """
+    image = np.asarray(image, dtype=float)
+    templates = np.asarray(templates, dtype=float)
+    if image.ndim != 2 or templates.ndim != 3:
+        raise ValueError("image must be 2D and templates 3D")
+
+    full_x, full_y = image.shape
+    full_xy = full_x * full_y
+
+    image = image - image.mean()
+    image_f = np.fft.fftn(np.fft.ifftshift(image))
+
+    n_templates = templates.shape[2]
+    out = np.empty((full_x, full_y, n_templates), dtype=float)
+    peaks = np.empty(n_templates, dtype=float)
+
+    for i in range(n_templates):
+        temp = templates[:, :, i]
+        temp = temp - temp.mean()
+        template = crop_or_pad(temp, image.shape, pad_value=0)
+        template_f = np.fft.fftn(np.fft.ifftshift(template))
+        v = np.sum(np.abs(template_f.ravel()) ** 2) / full_xy
+        denom = v / full_xy
+        template_f /= denom
+        cc_f = image_f * np.conj(template_f)
+        temp_cc = np.real(np.fft.fftshift(np.fft.ifftn(cc_f))) / full_xy
+        out[:, :, i] = temp_cc
+        peaks[i] = temp_cc.max()
+    return out, peaks

--- a/src/smap_tools_python/dose_filter.py
+++ b/src/smap_tools_python/dose_filter.py
@@ -1,0 +1,59 @@
+import numpy as np
+from .fft import ftj, iftj
+from .ks import get_ks
+
+
+def dose_filter(image_stack, total_dose, a_per_pix, norm_type="numerator_only", condition="LN"):
+    """Apply dose-weighting to a stack of movie frames.
+
+    Parameters
+    ----------
+    image_stack : ndarray
+        Stack of frames with shape ``(nx, ny, n_frames)``.
+    total_dose : float
+        Total exposure in e/Å² over the stack.
+    a_per_pix : float
+        Pixel size in Å/pixel.
+    norm_type : {"numerator_only", "noise_restored"}, optional
+        If ``"noise_restored"`` the noise power is restored after filtering.
+    condition : {"LN", "LHe"}, optional
+        Dose model; helium mode doubles the critical dose constants.
+
+    Returns
+    -------
+    ndarray
+        Dose-filtered sum of frames.
+    """
+
+    imref = np.asarray(image_stack, dtype=np.float32)
+    if imref.ndim != 3:
+        raise ValueError("image_stack must be 3-D")
+    edge_size, _, n_frames = imref.shape
+    dose_per_frame = float(total_dose) / n_frames
+
+    k, _ = get_ks(imref[:, :, 0], a_per_pix)
+    a, b, c = 0.24499, -1.6649, 2.8141
+    Nc = a * np.power(k, b) + c
+    if condition == "LHe":
+        Nc *= 2.0
+
+    outref = np.zeros((edge_size, edge_size), dtype=np.float32)
+    q2 = np.zeros_like(k, dtype=np.float32)
+
+    for i in range(n_frames):
+        N = dose_per_frame * (i + 1)
+        q = np.exp(-N / (2.0 * Nc))
+        frame = imref[:, :, i]
+        dc = frame.mean()
+        frame = frame - dc
+        frame = iftj(ftj(frame) * q)
+        outref += frame + dc
+        q2 += q ** 2
+
+    if norm_type == "noise_restored":
+        outref = iftj(ftj(outref) / np.sqrt(q2))
+
+    return outref
+
+
+__all__ = ["dose_filter"]

--- a/src/smap_tools_python/make_template_stack.py
+++ b/src/smap_tools_python/make_template_stack.py
@@ -1,0 +1,52 @@
+import numpy as np
+from .ccf import ccf
+from .max_interp_f import max_interp_f
+from .phase_shift import apply_phase_shifts
+from .crop_pad import extendj, cutj
+
+
+def make_template_stack(nf_im, templates=None, ref_template_stack=None):
+    """Align templates to an image and return their stack and sum.
+
+    Parameters
+    ----------
+    nf_im : ndarray
+        The noise-filtered image used for alignment.
+    templates : ndarray, optional
+        Stack of templates with shape ``(M, N, K)``.
+    ref_template_stack : ndarray, optional
+        Reference stack to provide initial alignment coordinates.
+
+    Returns
+    -------
+    tuple of (ndarray, ndarray)
+        ``ti`` is the summed template image and ``template_im`` contains the
+        individual aligned templates.
+    """
+    nf_im = np.asarray(nf_im, dtype=float)
+    if templates is None:
+        return np.zeros_like(nf_im), np.zeros(nf_im.shape + (0,), dtype=float)
+
+    templates = np.asarray(templates, dtype=float)
+    pad_val = np.nanmedian(templates)
+    ti = np.ones_like(nf_im, dtype=float) * pad_val
+    template_im = np.ones(nf_im.shape + (templates.shape[2],), dtype=float) * pad_val
+
+    for j in range(templates.shape[2]):
+        temp = templates[:, :, j]
+        if ref_template_stack is None:
+            cc, _ = ccf(nf_im, temp[:, :, None])
+            cc = cc[:, :, 0]
+        else:
+            cc, _ = ccf(nf_im, ref_template_stack[:, :, j][:, :, None])
+            cc = cc[:, :, 0]
+        yt, xt = np.unravel_index(np.argmax(cc), cc.shape)
+        shifts, _ = max_interp_f(cc, 10, 20, (yt, xt))
+        padded = extendj(temp, (2048, 2048), pad_val)
+        shifted = apply_phase_shifts(padded, shifts)
+        template_im[:, :, j] = cutj(shifted, (nf_im.shape[0], nf_im.shape[1]))
+        ti += template_im[:, :, j]
+
+    return ti, template_im
+
+__all__ = ["make_template_stack"]

--- a/src/smap_tools_python/read_dm_file.py
+++ b/src/smap_tools_python/read_dm_file.py
@@ -1,0 +1,48 @@
+"""Read Digital Micrograph DM3/DM4 files.
+
+This is a lightweight translation of SMAP's ``ReadDMFile`` MATLAB helper
+which extracts the image stack along with pixel size information.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Tuple
+import numpy as np
+
+try:  # pragma: no cover - optional dependency
+    from ncempy.io import dm
+except Exception:  # pragma: no cover
+    dm = None  # type: ignore
+
+
+def read_dm_file(path: str | Path) -> Tuple[np.ndarray, Tuple[float, float], str]:
+    """Load a DM3/DM4 file using :mod:`ncempy`.
+
+    Parameters
+    ----------
+    path : str or :class:`~pathlib.Path`
+        Input filename.
+
+    Returns
+    -------
+    tuple
+        ``(data, pixel_size, units)`` where ``data`` is a ``numpy.ndarray``,
+        ``pixel_size`` is a two element tuple giving the pixel spacing
+        in nanometers and ``units`` is the raw unit string stored in the
+        file metadata.
+    """
+    if dm is None:  # pragma: no cover
+        raise ImportError("ncempy is required to read DM files")
+
+    result = dm.dmReader(str(path))
+    data = np.asarray(result["data"])
+    px = result.get("pixelSize", (1.0, 1.0))
+    units = result.get("pixelUnit", "")
+
+    # ncempy returns pixel size in meters; convert to nanometers
+    if np.isscalar(px):
+        px_nm = (float(px) * 1e9, float(px) * 1e9)
+    else:
+        px_nm = tuple(float(v) * 1e9 for v in np.atleast_1d(px)[:2])
+
+    return data, px_nm, str(units)

--- a/src/smap_tools_python/ri.py
+++ b/src/smap_tools_python/ri.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import numpy as np
 
 from .mrc import read_mrc
+from .read_dm_file import read_dm_file
 
 try:  # pragma: no cover - optional dependency
     import tifffile
@@ -104,6 +105,9 @@ def ri(filename: str | Path):
     if ext == ".mrc":
         data, voxel = read_mrc(str(path))
         return data, {"voxel_size": voxel}
-    if ext == ".dm4":  # pragma: no cover - not yet implemented
-        raise NotImplementedError("DM4 reading not implemented")
+    if ext in (".dm3", ".dm4"):
+        data, px, units = read_dm_file(path)
+        info = {"voxel_size": (px[0] * 10, px[1] * 10, px[0] * 10), "units": units}
+        # convert nm to angstroms for voxel_size
+        return data, info
     raise ValueError(f"Unknown file type: {ext}")

--- a/src/smap_tools_python/run_ctffind.py
+++ b/src/smap_tools_python/run_ctffind.py
@@ -1,0 +1,45 @@
+import subprocess
+from pathlib import Path
+
+
+def run_ctffind(obj):
+    """Run the external *ctffind* program using parameters from ``obj``.
+
+    The input ``obj`` is expected to be a mapping or object with ``CTF`` and
+    ``proc`` attributes/keys mirroring the MATLAB structure. The function writes
+    the parameter file, executes ``ctffind`` and parses the diagnostic output to
+    populate ``obj['final']`` and ``obj['ID']`` entries.
+    """
+    # support both attribute and dict style access
+    ctf_params = getattr(obj, "CTF", obj["CTF"])
+    proc = getattr(obj, "proc", obj["proc"])
+    out = getattr(obj, "final", obj.setdefault("final", {}))
+    ident = getattr(obj, "ID", obj.setdefault("ID", {}))
+
+    # write the parameter file expected by ctffind
+    params = {}
+    for key, val in ctf_params.items():
+        params[key] = str(val)
+    base = Path(proc["fullSum_image"])
+    fn_out = base.with_name(base.stem + "_CTFFind_input.txt")
+    with open(fn_out, "w") as fh:
+        for k, v in params.items():
+            fh.write(f"{k} {v}\n")
+
+    # execute ctffind
+    subprocess.run(["ctffind", str(fn_out)], check=True)
+
+    # read diagnostic output
+    diag_base = Path(ctf_params["output_diag_filename"])
+    diag_fn = diag_base.with_suffix(".txt")
+    with open(diag_fn, "r") as fh:
+        lines = fh.readlines()[5:12]
+    vals = [float(line.split()[0]) for line in lines[:7]]
+
+    out["df1"] = vals[1] / 10.0
+    out["df2"] = vals[2] / 10.0
+    out["ast"] = vals[3] * 3.141592653589793 / 180.0
+    ident["CTF"] = 1
+    return obj
+
+__all__ = ["run_ctffind"]

--- a/src/smap_tools_python/write_mrc_header.py
+++ b/src/smap_tools_python/write_mrc_header.py
@@ -1,0 +1,56 @@
+import numpy as np
+
+
+def write_mrc_header(map_array, voxel_size, filename, n_images=None):
+    """Write an MRC header and return an open file handle.
+
+    Parameters
+    ----------
+    map_array : array-like
+        Sample data whose shape and statistics populate the header.
+    voxel_size : float
+        Voxel size in ångström.
+    filename : str
+        Output file path.
+    n_images : int, optional
+        Number of sections expected in the file. Defaults to the third
+        dimension of ``map_array``.
+
+    Returns
+    -------
+    file object
+        Handle positioned after the 1024-byte header ready for sequential
+        writes.
+    """
+
+    arr = np.asarray(map_array, dtype=np.float32)
+    sizes = list(arr.shape)
+    if len(sizes) < 3:
+        sizes += [1] * (3 - len(sizes))
+    if n_images is not None:
+        sizes[2] = int(n_images)
+
+    hdr = np.zeros(256, dtype=np.int32)
+    hdr[0:3] = sizes  # dimensions
+    hdr[3] = 2  # mode 2 = float32
+    hdr[7:10] = sizes  # number of intervals
+
+    def _flt(val):
+        return np.asarray(val, dtype=np.float32).view(np.int32)
+
+    hdr[10:13] = _flt(np.array(sizes, dtype=np.float32) * float(voxel_size))
+    hdr[13:16] = _flt([90.0, 90.0, 90.0])
+    hdr[16:19] = [1, 2, 3]
+    stats = [arr.min(), arr.max(), arr.mean()]
+    hdr[19:22] = _flt(stats)
+    hdr[22] = 0
+    hdr[52] = int.from_bytes(b"MAP ", "little")
+    hdr[53] = int.from_bytes(bytes([68, 65, 0, 0]), "little")
+    hdr[54] = _flt(arr.std())
+
+    handle = open(filename, "wb")
+    hdr.tofile(handle)
+    return handle
+
+
+__all__ = ["write_mrc_header"]

--- a/tests/test_ccfn_ccfv.py
+++ b/tests/test_ccfn_ccfv.py
@@ -1,0 +1,24 @@
+import numpy as np
+from smap_tools_python import ccfn, ccfv
+
+
+def test_ccfn_peak():
+    rng = np.random.default_rng(0)
+    image = rng.normal(size=(8, 8))
+    templates = np.stack([image.copy(), rng.normal(size=(8, 8))], axis=-1)
+    cc, peaks = ccfn(image, templates)
+    assert cc.shape == (8, 8, 2)
+    assert peaks[0] > peaks[1]
+    max_pos = np.unravel_index(np.argmax(cc[:, :, 0]), (8, 8))
+    assert max_pos == (4, 4)
+
+
+def test_ccfv_peak():
+    rng = np.random.default_rng(0)
+    image = rng.normal(size=(8, 8))
+    templates = np.stack([image.copy(), rng.normal(size=(8, 8))], axis=-1)
+    cc, peaks = ccfv(image, templates)
+    assert cc.shape == (8, 8, 2)
+    assert peaks[0] > peaks[1]
+    max_pos = np.unravel_index(np.argmax(cc[:, :, 0]), (8, 8))
+    assert max_pos == (4, 4)


### PR DESCRIPTION
## Summary
- implement DM3/DM4 reader using ncempy and wire into `ri`
- enable SMAP image loader to return voxel size for DM files
- expose `read_dm_file` and declare ncempy dependency
- run external CTFFIND and template stack generators
- add MRC header writer and dose filtering helper
- port `ccfn` and `ccfv` MATLAB cross-correlation functions

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68bdd8f30abc832899b53a9bac9d5645