### PR TITLE
Add DM reader, CTFFIND, dose handling, cross-correlation, icosahedral utilities, detector estimator, template generation, GPU template helpers, motion correction, and potential/backprojection utilities

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ scipy
 pytest
 mrcfile
 openpyxl
+ncempy

--- a/src/smap_tools_python/__init__.py
+++ b/src/smap_tools_python/__init__.py
@@ -44,10 +44,12 @@ from .getcp import get_center_pixel, getcp
 from .mrc import read_mrc, write_mrc
 from .mr import mr
 from .ri import tr, ri, tw
+from .read_dm_file import read_dm_file
 from .bindata import bindata
 from .particle_diameter import particle_diameter
 from .resize_f import resize_F
 from .sum_frames import sum_frames
+from .motion_corr import motion_corr
 from .whoami import whoami
 from .occ import occ
 from .apply_filter import apply_filter
@@ -74,6 +76,15 @@ from .mw import mw
 from .cif import read_cif_file
 from .pdb import read_pdb_file
 from .ccf import ccf
+from .ccfn import ccfn
+from .ccfv import ccfv
+from .ccff import ccff
+from .ccff_gpu import ccff_gpu
+from .ccff_bak_041423 import ccff_bak_041423
+from .templates import templates
+from .templates_gpu import templates_gpu, templates_half_gpu
+from .get_dots import get_dots
+from .preprocess import preprocess
 from .cluster_im_by_thr import cluster_im_by_thr
 from .dust import dust
 from .proj_view import proj_view
@@ -119,6 +130,17 @@ from .smap2cistem import smap2cistem
 from .register_multiple_fragments import register_multiple_fragments
 from .ipcc import ipcc, ipcc_m
 from .write_search_params import write_search_params, writeSearchParams
+from .run_ctffind import run_ctffind
+from .make_template_stack import make_template_stack
+from .write_mrc_header import write_mrc_header
+from .dose_filter import dose_filter
+from .gain_corr import gain_corr
+from .icos import icos
+from .get_icos import get_icos
+from .estimate_detector import estimate_detector
+from .ep2sp import ep2sp
+from .pdb2ep import pdb2ep
+from .backproject import backproject
 
 
 quaternion = Quaternion
@@ -181,6 +203,7 @@ __all__ = [
     "tw",
     "bindata",
     "sum_frames",
+    "motion_corr",
     "particle_diameter",
     "whoami",
     "occ",
@@ -203,6 +226,15 @@ __all__ = [
     "read_cif_file",
     "read_pdb_file",
     "ccf",
+    "ccfn",
+    "ccfv",
+    "ccff",
+    "ccff_gpu",
+    "ccff_bak_041423",
+    "templates",
+    "templates_gpu",
+    "templates_half_gpu",
+    "get_dots",
     "cluster_im_by_thr",
     "dust",
     "proj_view",
@@ -251,6 +283,18 @@ __all__ = [
     "getDataset",
     "getDatasets",
     "putDataset",
+    "run_ctffind",
+    "make_template_stack",
+    "write_mrc_header",
+    "dose_filter",
+    "gain_corr",
+    "icos",
+    "get_icos",
+    "estimate_detector",
+    "ep2sp",
+    "pdb2ep",
+    "backproject",
+    "preprocess",
     "smap2pymol",
     "smap2frealign",
     "smap2cistem",

--- a/src/smap_tools_python/backproject.py
+++ b/src/smap_tools_python/backproject.py
@@ -1,0 +1,58 @@
+import numpy as np
+
+from .crop_pad import extendj
+from .rotate import rotate3d_matrix
+
+
+def backproject(patches, rotations, pad_size=None):
+    """Backproject 2-D patches into a 3-D volume.
+
+    A simple real-space backprojection is performed by inserting each patch as
+    a central slice of a cubic volume, rotating it according to ``rotations``
+    and summing the results.
+
+    Parameters
+    ----------
+    patches : array_like, shape (N, N, M)
+        Stack of projection images.
+    rotations : array_like, shape (M, 3, 3) or (3, 3, M)
+        Rotation matrices associated with each patch.
+    pad_size : int, optional
+        Edge length of the output volume. Defaults to ``N``.
+
+    Returns
+    -------
+    numpy.ndarray
+        Reconstructed volume of shape ``(pad_size, pad_size, pad_size)``.
+    """
+
+    patches = np.asarray(patches, dtype=float)
+    if patches.ndim != 3:
+        raise ValueError("patches must have shape (N, N, M)")
+
+    n, m, k = patches.shape
+    if n != m:
+        raise ValueError("patches must be square")
+
+    pad_size = int(pad_size or n)
+    vol = np.zeros((pad_size, pad_size, pad_size), dtype=float)
+
+    rotations = np.asarray(rotations, dtype=float)
+    if rotations.shape[-2:] != (3, 3):
+        raise ValueError("rotations must contain 3x3 matrices")
+    if rotations.shape[0] == 3 and rotations.shape[1] == 3 and rotations.ndim == 3:
+        rotations = np.transpose(rotations, (2, 0, 1))
+    if rotations.shape[0] != k:
+        raise ValueError("Number of rotation matrices must match patches")
+
+    center = pad_size // 2
+    for i in range(k):
+        patch = extendj(patches[:, :, i], (pad_size, pad_size), float(patches[:, :, i].mean()))
+        slice_vol = np.zeros_like(vol)
+        slice_vol[:, :, center] = patch
+        vol += rotate3d_matrix(slice_vol, rotations[i])
+
+    return vol / float(k)
+
+
+__all__ = ["backproject"]

--- a/src/smap_tools_python/ccff.py
+++ b/src/smap_tools_python/ccff.py
@@ -1,0 +1,61 @@
+import numpy as np
+from .psd_filter import psd_filter
+from .crop_pad import crop_or_pad
+from .nm import nm
+
+
+def ccff(image: np.ndarray, templates: np.ndarray, mode: str = "filt"):
+    """Whitened cross-correlation of an image with templates.
+
+    Parameters
+    ----------
+    image : ndarray, shape (M, N)
+        Input image.
+    templates : ndarray, shape (M_t, N_t, K)
+        Stack of ``K`` templates.
+    mode : {"filt", "noFilt"}, optional
+        If ``"filt"`` (default) the image is radially whitened prior to
+        correlation using :func:`psd_filter`.  ``"noFilt"`` skips whitening.
+
+    Returns
+    -------
+    tuple of (ndarray, ndarray)
+        The cross-correlation volume of shape ``(M, N, K)`` and the peak value
+        for each template.
+    """
+    image = np.asarray(image, dtype=float)
+    templates = np.asarray(templates, dtype=float)
+    if image.ndim != 2 or templates.ndim != 3:
+        raise ValueError("image must be 2D and templates 3D")
+
+    if mode not in {"filt", "noFilt"}:
+        raise ValueError("mode must be 'filt' or 'noFilt'")
+
+    if mode == "filt":
+        f_psd, im_filt, _ = psd_filter(image, method="sqrt")
+        im_filt = nm(im_filt)
+    else:
+        f_psd = np.ones_like(image)
+        im_filt = nm(image)
+
+    imref_F = np.fft.fftn(np.fft.ifftshift(im_filt)) / np.sqrt(image.size)
+    f_psd = np.fft.ifftshift(f_psd)
+
+    n_templates = templates.shape[2]
+    out = np.empty((image.shape[0], image.shape[1], n_templates), dtype=float)
+    peaks = np.empty(n_templates, dtype=float)
+
+    for i in range(n_templates):
+        temp = templates[:, :, i]
+        temp = crop_or_pad(temp, image.shape, pad_value=np.median(temp))
+        temp = nm(temp)
+        template_F = np.fft.fftn(np.fft.ifftshift(temp)) / temp.size
+        if mode == "filt":
+            template_F *= f_psd
+        template_F /= template_F.std()
+        cc_F = imref_F * np.conj(template_F)
+        cc = np.real(np.fft.fftshift(np.fft.ifftn(cc_F))) * np.sqrt(image.size)
+        out[:, :, i] = cc
+        peaks[i] = cc.max()
+
+    return out, peaks

--- a/src/smap_tools_python/ccff_bak_041423.py
+++ b/src/smap_tools_python/ccff_bak_041423.py
@@ -1,0 +1,25 @@
+import numpy as np
+from .ccff import ccff
+
+
+def ccff_bak_041423(image: np.ndarray, templates: np.ndarray, mode: str = "filt"):
+    """Legacy wrapper around :func:`ccff`.
+
+    Parameters
+    ----------
+    image : ndarray
+        2-D image to correlate with templates.
+    templates : ndarray
+        Stack of templates matching the image size.
+    mode : {"filt", "noFilt"}, optional
+        Whitening mode passed through to :func:`ccff`.
+
+    Returns
+    -------
+    tuple of (ndarray, ndarray)
+        Cross-correlation volume and peak values, as produced by :func:`ccff`.
+    """
+    return ccff(image, templates, mode)
+
+
+__all__ = ["ccff_bak_041423"]

--- a/src/smap_tools_python/ccff_gpu.py
+++ b/src/smap_tools_python/ccff_gpu.py
@@ -1,0 +1,58 @@
+import numpy as np
+from .ccff import ccff
+from .crop_pad import crop_or_pad
+from .nm import nm
+
+try:
+    import cupy as cp
+except Exception:  # pragma: no cover - optional dependency
+    cp = None
+
+
+def ccff_gpu(image, templates, mode="filt"):
+    """GPU-accelerated :func:`ccff` using CuPy when available.
+
+    When CuPy is not installed this function falls back to the CPU
+    implementation. The API mirrors :func:`ccff`.
+    """
+    if cp is None:
+        return ccff(np.asarray(image), np.asarray(templates), mode)
+
+    image_gpu = cp.asarray(image, dtype=cp.float32)
+    templates_gpu = cp.asarray(templates, dtype=cp.float32)
+
+    if mode == "filt":
+        from .psd_filter import psd_filter
+
+        f_psd, im_filt, _ = psd_filter(cp.asnumpy(image_gpu), method="sqrt")
+        im_filt = nm(im_filt)
+        f_psd = cp.asarray(np.fft.ifftshift(f_psd))
+        im_filt = cp.asarray(im_filt)
+    else:
+        f_psd = cp.ones_like(image_gpu)
+        im_filt = cp.asarray(nm(cp.asnumpy(image_gpu)))
+
+    imref_F = cp.fft.fftn(cp.fft.ifftshift(im_filt)) / cp.sqrt(image_gpu.size)
+
+    n_templates = templates_gpu.shape[2]
+    out = cp.empty((image_gpu.shape[0], image_gpu.shape[1], n_templates), dtype=cp.float32)
+    peaks = cp.empty(n_templates, dtype=cp.float32)
+
+    for i in range(n_templates):
+        temp = cp.asnumpy(templates_gpu[:, :, i])
+        temp = crop_or_pad(temp, image_gpu.shape[:2], pad_value=float(np.median(temp)))
+        temp = nm(temp)
+        temp_gpu = cp.asarray(temp)
+        template_F = cp.fft.fftn(cp.fft.ifftshift(temp_gpu)) / temp_gpu.size
+        if mode == "filt":
+            template_F *= f_psd
+        template_F /= cp.std(template_F)
+        cc_F = imref_F * cp.conj(template_F)
+        cc = cp.real(cp.fft.fftshift(cp.fft.ifftn(cc_F))) * cp.sqrt(image_gpu.size)
+        out[:, :, i] = cc
+        peaks[i] = cp.max(cc)
+
+    return cp.asnumpy(out), cp.asnumpy(peaks)
+
+
+__all__ = ["ccff_gpu"]

--- a/src/smap_tools_python/ccfn.py
+++ b/src/smap_tools_python/ccfn.py
@@ -1,0 +1,62 @@
+import numpy as np
+from .crop_pad import crop_or_pad
+from .radial import radial_average_im
+
+
+def ccfn(image, templates):
+    """Frequency-normalized cross-correlation.
+
+    Parameters
+    ----------
+    image : ndarray, shape (M, N)
+        Input 2D image.
+    templates : ndarray, shape (M_t, N_t, K)
+        Stack of ``K`` templates.
+
+    Returns
+    -------
+    tuple of (ndarray, ndarray)
+        ``cc`` is the cross-correlation volume of shape ``(M, N, K)`` and
+        ``peaks`` holds the maximum value for each template.
+    """
+    image = np.asarray(image, dtype=float)
+    templates = np.asarray(templates, dtype=float)
+    if image.ndim != 2 or templates.ndim != 3:
+        raise ValueError("image must be 2D and templates 3D")
+
+    full_x, full_y = image.shape
+    full_xy = full_x * full_y
+    cp = full_x // 2
+
+    # Zero-mean image and estimate power spectral density via radial averaging
+    image = image - image.mean()
+    f_amp = np.abs(np.fft.fftshift(np.fft.fftn(np.fft.ifftshift(image)))) / full_x
+    f_amp_r = radial_average_im(f_amp)
+    f_amp_r[cp, cp] = 1.0
+    f_amp_r_inv = 1.0 / f_amp_r
+    f_amp_r_inv[cp, cp] = np.nan
+    f_amp_r_inv[cp, cp] = np.nanmean(
+        f_amp_r_inv[cp - 1 : cp + 2, cp - 1 : cp + 2]
+    )
+    f_psd = (f_amp_r_inv / np.sum(np.abs(f_amp_r_inv.ravel()) ** 2)) * (full_x ** 2)
+    f_psd = np.fft.ifftshift(f_psd)
+
+    image_f = np.fft.fftn(np.fft.ifftshift(image)) * f_psd
+    v = np.sum(np.abs(image_f.ravel()) ** 2) / full_xy
+    denom = np.sqrt(v / full_xy)
+    image_f /= denom
+
+    n_templates = templates.shape[2]
+    out = np.empty((full_x, full_y, n_templates), dtype=float)
+    peaks = np.empty(n_templates, dtype=float)
+
+    for i in range(n_templates):
+        temp = templates[:, :, i]
+        temp = temp - temp.mean()
+        template = crop_or_pad(temp, image.shape, pad_value=0)
+        template_f = np.fft.fftn(np.fft.ifftshift(template)) * f_psd
+        cc_f = image_f * np.conj(template_f)
+        temp_cc = np.real(np.fft.fftshift(np.fft.ifftn(cc_f)))
+        out[:, :, i] = temp_cc
+        peaks[i] = temp_cc.max()
+    return out, peaks

--- a/src/smap_tools_python/ccfv.py
+++ b/src/smap_tools_python/ccfv.py
@@ -1,0 +1,48 @@
+import numpy as np
+from .crop_pad import crop_or_pad
+
+
+def ccfv(image, templates):
+    """Variance-normalized cross-correlation.
+
+    Parameters
+    ----------
+    image : ndarray, shape (M, N)
+        Input 2D image.
+    templates : ndarray, shape (M_t, N_t, K)
+        Stack of ``K`` templates.
+
+    Returns
+    -------
+    tuple of (ndarray, ndarray)
+        ``cc`` is the cross-correlation volume of shape ``(M, N, K)`` and
+        ``peaks`` holds the maximum value for each template.
+    """
+    image = np.asarray(image, dtype=float)
+    templates = np.asarray(templates, dtype=float)
+    if image.ndim != 2 or templates.ndim != 3:
+        raise ValueError("image must be 2D and templates 3D")
+
+    full_x, full_y = image.shape
+    full_xy = full_x * full_y
+
+    image = image - image.mean()
+    image_f = np.fft.fftn(np.fft.ifftshift(image))
+
+    n_templates = templates.shape[2]
+    out = np.empty((full_x, full_y, n_templates), dtype=float)
+    peaks = np.empty(n_templates, dtype=float)
+
+    for i in range(n_templates):
+        temp = templates[:, :, i]
+        temp = temp - temp.mean()
+        template = crop_or_pad(temp, image.shape, pad_value=0)
+        template_f = np.fft.fftn(np.fft.ifftshift(template))
+        v = np.sum(np.abs(template_f.ravel()) ** 2) / full_xy
+        denom = v / full_xy
+        template_f /= denom
+        cc_f = image_f * np.conj(template_f)
+        temp_cc = np.real(np.fft.fftshift(np.fft.ifftn(cc_f))) / full_xy
+        out[:, :, i] = temp_cc
+        peaks[i] = temp_cc.max()
+    return out, peaks

--- a/src/smap_tools_python/dose_filter.py
+++ b/src/smap_tools_python/dose_filter.py
@@ -1,0 +1,59 @@
+import numpy as np
+from .fft import ftj, iftj
+from .ks import get_ks
+
+
+def dose_filter(image_stack, total_dose, a_per_pix, norm_type="numerator_only", condition="LN"):
+    """Apply dose-weighting to a stack of movie frames.
+
+    Parameters
+    ----------
+    image_stack : ndarray
+        Stack of frames with shape ``(nx, ny, n_frames)``.
+    total_dose : float
+        Total exposure in e/Å² over the stack.
+    a_per_pix : float
+        Pixel size in Å/pixel.
+    norm_type : {"numerator_only", "noise_restored"}, optional
+        If ``"noise_restored"`` the noise power is restored after filtering.
+    condition : {"LN", "LHe"}, optional
+        Dose model; helium mode doubles the critical dose constants.
+
+    Returns
+    -------
+    ndarray
+        Dose-filtered sum of frames.
+    """
+
+    imref = np.asarray(image_stack, dtype=np.float32)
+    if imref.ndim != 3:
+        raise ValueError("image_stack must be 3-D")
+    edge_size, _, n_frames = imref.shape
+    dose_per_frame = float(total_dose) / n_frames
+
+    k, _ = get_ks(imref[:, :, 0], a_per_pix)
+    a, b, c = 0.24499, -1.6649, 2.8141
+    Nc = a * np.power(k, b) + c
+    if condition == "LHe":
+        Nc *= 2.0
+
+    outref = np.zeros((edge_size, edge_size), dtype=np.float32)
+    q2 = np.zeros_like(k, dtype=np.float32)
+
+    for i in range(n_frames):
+        N = dose_per_frame * (i + 1)
+        q = np.exp(-N / (2.0 * Nc))
+        frame = imref[:, :, i]
+        dc = frame.mean()
+        frame = frame - dc
+        frame = iftj(ftj(frame) * q)
+        outref += frame + dc
+        q2 += q ** 2
+
+    if norm_type == "noise_restored":
+        outref = iftj(ftj(outref) / np.sqrt(q2))
+
+    return outref
+
+
+__all__ = ["dose_filter"]

--- a/src/smap_tools_python/ep2sp.py
+++ b/src/smap_tools_python/ep2sp.py
@@ -1,0 +1,64 @@
+import numpy as np
+
+from .crop_pad import extendj
+from .resize_f import resize_F
+from .particle_diameter import particle_diameter
+from .phase_shift import apply_phase_shifts
+from .constants import def_consts
+
+
+def ep2sp(pv, nm_per_voxel_ep, nm_per_voxel_sp):
+    """Convert electrostatic potential to scattering potential.
+
+    Parameters
+    ----------
+    pv : array_like
+        Input electrostatic potential volume.
+    nm_per_voxel_ep : float
+        Voxel size of the input volume in nanometres.
+    nm_per_voxel_sp : float
+        Desired voxel size of the output scattering potential in nanometres.
+
+    Returns
+    -------
+    tuple
+        ``(spv, a_per_pix)`` where ``spv`` is the scattering potential volume
+        and ``a_per_pix`` is the final voxel size in Ångström.
+    """
+
+    pv = np.asarray(pv, dtype=float)
+
+    # ensure cubic volume by padding with the minimum value
+    min_dim = min(pv.shape)
+    max_dim = max(pv.shape)
+    if min_dim < max_dim:
+        pv_cube = extendj(pv, (max_dim, max_dim, max_dim), float(pv.min()))
+    else:
+        pv_cube = pv
+
+    # subtract background value
+    pv_cube = pv_cube - pv_cube.flat[0]
+
+    # resize to the desired voxel size
+    scale = float(nm_per_voxel_ep) / float(nm_per_voxel_sp)
+    spv = resize_F(pv_cube, scale)
+
+    # determine padding size from estimated particle diameter
+    pd = particle_diameter(spv, 0.05)
+    edge = int(max(2.5 * pd, max(spv.shape)))
+    spv = extendj(spv, (edge, edge, edge), 0)
+
+    consts = def_consts()
+    a_per_pix = float(nm_per_voxel_sp) * 10.0  # convert nm to Å
+    dx = a_per_pix / 1e10  # metres
+
+    spv = spv * consts["IC"] * dx / (2.0 * consts["k"])
+
+    # reverse z-axis to preserve handedness and apply phase shift
+    spv = spv[:, :, ::-1]
+    spv = apply_phase_shifts(spv, (0, 0, 1)).real.astype(np.float32)
+
+    return spv, a_per_pix
+
+
+__all__ = ["ep2sp"]

--- a/src/smap_tools_python/estimate_detector.py
+++ b/src/smap_tools_python/estimate_detector.py
@@ -1,0 +1,78 @@
+import numpy as np
+from typing import Sequence
+
+from .mr import mr
+from .crop_pad import cutj
+from .fft import ftj
+from .rrj import rrj
+from .radial import radialmeanIm
+
+
+def estimate_detector(file_paths: Sequence[str], frame_index: int = 0) -> np.ndarray:
+    """Estimate detector whitening filter from micrograph cross spectra.
+
+    Parameters
+    ----------
+    file_paths : sequence of str
+        Paths to MRC files containing individual movie frames or images.
+    frame_index : int, optional
+        Zero-based index of the slice to read from each stack.  Defaults to 0.
+
+    Returns
+    -------
+    numpy.ndarray
+        Radially averaged inverse cross-spectrum suitable for whitening.
+    """
+    file_paths = list(file_paths)
+    if not file_paths:
+        raise ValueError("file_paths must be non-empty")
+
+    # Read first frame to establish edge size
+    first, _ = mr(file_paths[0], start_slice=frame_index + 1, num_slices=1)
+    sample = first[:, :, 0]
+    edge_size = int(min(sample.shape))
+    center = edge_size // 2
+
+    # Load and square-crop all frames
+    frames = []
+    for fn in file_paths:
+        data, _ = mr(fn, start_slice=frame_index + 1, num_slices=1)
+        frames.append(cutj(data[:, :, 0], (edge_size, edge_size)).astype(float))
+    frames = np.asarray(frames)
+    n_frames = frames.shape[0]
+
+    # Accumulate cross-spectral density across frame pairs
+    im_F_sum = np.zeros((edge_size, edge_size), dtype=np.float64)
+    for i in range(n_frames):
+        a_F = ftj(frames[i])
+        a_F[center, center] = 0
+        for j in range(i + 1, n_frames):
+            b_F = ftj(frames[j])
+            b_F[center, center] = 0
+            im_F_sum += np.sqrt(np.abs(a_F * np.conj(b_F)))
+
+    # Build masks mimicking MATLAB implementation
+    mask_floor = rrj(np.ones((edge_size, edge_size))) * edge_size
+    ring = np.abs(mask_floor - (edge_size / 2.0)) < 25
+    mask_floor = np.full((edge_size, edge_size), np.nan)
+    mask_floor[ring] = 1.0
+
+    mask_cross = np.ones((edge_size, edge_size))
+    mask_cross[center, :] = np.nan
+    mask_cross[:, center] = np.nan
+
+    mask_center = rrj(np.ones((edge_size, edge_size))) * edge_size
+    mask_center[mask_center <= 3.5] = np.nan
+    mask_center[mask_center > 3.5] = 1.0
+    mask = mask_center * mask_cross
+
+    csd = im_F_sum
+    csd_masked = csd * mask
+    csd_floor = np.nanmean(csd_masked * mask_floor)
+    csd_masked = np.where(np.isnan(csd_masked), csd_floor, csd_masked)
+    csd_masked /= csd_floor
+
+    profile = radialmeanIm(csd_masked)
+    inv_profile = np.reciprocal(profile, where=profile != 0)
+    inv_profile[~np.isfinite(inv_profile)] = 1.0
+    return inv_profile

--- a/src/smap_tools_python/gain_corr.py
+++ b/src/smap_tools_python/gain_corr.py
@@ -1,0 +1,43 @@
+import numpy as np
+
+
+def gain_corr(movie: np.ndarray, gain: np.ndarray, hot_threshold: float = 7.0):
+    """Apply gain correction and remove hot pixels from a movie stack.
+
+    Parameters
+    ----------
+    movie : ndarray, shape (M, N, F)
+        Stack of ``F`` frames.
+    gain : ndarray, shape (M, N)
+        Gain reference image.  Each frame is multiplied by this reference.
+    hot_threshold : float, optional
+        Pixels whose mean across the stack exceeds ``hot_threshold`` standard
+        deviations are replaced by the mean of their ``3x3`` neighbourhood in
+        each frame.
+
+    Returns
+    -------
+    corrected : ndarray
+        Gain-corrected movie.
+    hot_pixels : ndarray, shape (K, 2)
+        Coordinates of replaced hot pixels.
+    """
+    movie = np.asarray(movie, dtype=float)
+    gain = np.asarray(gain, dtype=float)
+    if movie.ndim != 3:
+        raise ValueError("movie must be 3D (M, N, F)")
+    if gain.shape != movie.shape[:2]:
+        raise ValueError("gain shape must match movie xy dimensions")
+
+    corrected = movie * gain[..., None]
+    mean_im = corrected.mean(axis=2)
+    z = (mean_im - mean_im.mean()) / mean_im.std()
+    hot = np.argwhere(z > hot_threshold)
+
+    for x, y in hot:
+        xs = slice(max(x - 1, 0), min(x + 2, corrected.shape[0]))
+        ys = slice(max(y - 1, 0), min(y + 2, corrected.shape[1]))
+        neighbourhood = corrected[xs, ys, :]
+        corrected[x, y, :] = neighbourhood.reshape(-1, neighbourhood.shape[-1]).mean(axis=0)
+
+    return corrected, hot

--- a/src/smap_tools_python/get_dots.py
+++ b/src/smap_tools_python/get_dots.py
@@ -1,0 +1,66 @@
+import numpy as np
+
+from .templates import templates
+from .rrj import rrj
+from .particle_diameter import particle_diameter
+
+
+def get_dots(volume, rotations, df, edge_size=None, n_samples=1000, pixel_size=1.0):
+    """Estimate dot-product statistics from random template orientations.
+
+    Parameters
+    ----------
+    volume : ndarray, shape (Z, Y, X)
+        Scattering potential volume from which templates are generated.
+    rotations : ndarray, shape (3, 3, N)
+        Rotation matrices describing possible orientations.
+    df : array_like, shape (3,), optional
+        Defocus triplet used for all templates. ``None`` disables CTF
+        modulation.
+    edge_size : int, optional
+        Output template size. Defaults to the volume size.
+    n_samples : int, optional
+        Number of random orientations to sample. Defaults to 1000.
+    pixel_size : float, optional
+        Pixel size in Angstroms passed to :func:`templates`.
+
+    Returns
+    -------
+    tuple of float
+        Mean and standard deviation of the masked template standard
+        deviations, matching the MATLAB ``getDots`` heuristic.
+    """
+    vol = np.asarray(volume, float)
+    rot = np.asarray(rotations, float)
+    if rot.shape != (3, 3, rot.shape[2]):
+        rot = rot.reshape(3, 3, -1)
+    n_templates = rot.shape[2]
+
+    rng = np.random.default_rng(1)
+    if n_samples > n_templates:
+        n_samples = n_templates
+    rand_inds = rng.permutation(n_templates)[:n_samples]
+
+    if edge_size is None:
+        edge_size = vol.shape[0]
+
+    tt = templates(vol, rot[:, :, rand_inds], df, pixel_size, edge_size)
+    bg_val = np.median(tt)
+
+    mask_size = min(particle_diameter(vol) * 1.25, edge_size)
+    Rmask = rrj((edge_size, edge_size)) * (edge_size / 0.5)
+    mask = np.ones_like(Rmask)
+    mask[Rmask > (mask_size / 2)] = np.nan
+
+    dots = []
+    for i in range(tt.shape[2]):
+        template = tt[:, :, i] - bg_val
+        t_masked = template * mask
+        dots.append(np.nanstd(t_masked))
+    dots = np.asarray(dots)
+    dot_mean = float(dots.mean() * 1.125)
+    dot_std = float(dots.std())
+    return dot_mean, dot_std
+
+
+__all__ = ["get_dots"]

--- a/src/smap_tools_python/get_icos.py
+++ b/src/smap_tools_python/get_icos.py
@@ -1,0 +1,50 @@
+"""Utilities for working with icosahedral symmetry."""
+
+from __future__ import annotations
+
+import numpy as np
+from scipy.spatial.transform import Rotation
+
+from .icos import icos
+
+
+def get_icos(
+    q_best: np.ndarray,
+    new_icos_flag: bool | int = True,
+    a_per_vox: float = 0.97,
+):
+    """Return icosahedral symmetry operations and rotated reference points.
+
+    Parameters
+    ----------
+    q_best : array_like, shape (4,)
+        Quaternion representing the best orientation.  The quaternion should be
+        in the ``[x, y, z, w]`` convention used by :mod:`scipy`.
+    new_icos_flag : bool, optional
+        Present for API compatibility with the MATLAB version.  It is ignored
+        as the Python implementation always generates operations analytically.
+    a_per_vox : float, optional
+        Angstroms per voxel used to scale the returned coordinates.
+
+    Returns
+    -------
+    tuple
+        ``(q_out, xyz_sub, xyz_rnap)`` where ``q_out`` is an array of 60
+        quaternions representing the icosahedral symmetry operations applied to
+        ``q_best`` and the coordinate arrays hold the rotated reference points
+        for each asymmetric unit.
+    """
+
+    base = Rotation.from_quat(np.asarray(q_best))
+    ops = Rotation.create_group("I")
+    q_out = (base * ops).as_quat()
+
+    xyz_sub, xyz_rnap = icos(a_per_vox)
+    xyz_sub = base.apply(xyz_sub)
+    xyz_rnap = base.apply(xyz_rnap)
+
+    return q_out, xyz_sub, xyz_rnap
+
+
+__all__ = ["get_icos"]
+

--- a/src/smap_tools_python/icos.py
+++ b/src/smap_tools_python/icos.py
@@ -1,0 +1,59 @@
+"""Generate positions for icosahedral symmetry axes.
+
+This is a light-weight replacement for the MATLAB ``smap.icos`` helper which
+loaded precomputed coordinates from ``rotaXYZ.mat`` and ``rnapXYZ.mat``.  The
+original function returned the centres of mass for each asymmetric unit of an
+icosahedral particle along with a second set of reference points associated
+with the genome.  The exact values are not important for most workflows – any
+set of vectors related by icosahedral symmetry will suffice – so here we
+derive them on the fly using :mod:`scipy`'s built in icosahedral rotation
+group.
+
+The returned vectors are scaled such that their distance from the origin is
+``0.97 / a_per_vox`` which mimics the behaviour of the original MATLAB code
+that normalised coordinates by the voxel size.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from scipy.spatial.transform import Rotation
+
+
+def icos(a_per_vox: float = 0.97) -> tuple[np.ndarray, np.ndarray]:
+    """Return two sets of vectors related by icosahedral symmetry.
+
+    Parameters
+    ----------
+    a_per_vox : float, optional
+        Angstroms per voxel (defaults to ``0.97`` which keeps the returned
+        vectors on the unit sphere).
+
+    Returns
+    -------
+    tuple of ``ndarray``
+        ``(xyz_sub, xyz_rnap)`` where each array has shape ``(60, 3)``.  The
+        first corresponds to the asymmetric unit centres on the capsid and the
+        second is a second reference set (historically used for RNA positions).
+    """
+
+    # Build the icosahedral rotation group (60 orientations)
+    group = Rotation.create_group("I")
+
+    # Two arbitrary non-collinear reference vectors.  Applying the icosahedral
+    # group to these generates two complete sets of symmetry-related
+    # coordinates.  The specific choice of vectors is unimportant so long as
+    # they are not parallel.
+    base_sub = np.array([0.0, 0.0, 1.0])
+    base_rnap = np.array([1.0, 0.0, 0.0])
+
+    scale = 0.97 / float(a_per_vox)
+
+    xyz_sub = group.apply(base_sub) * scale
+    xyz_rnap = group.apply(base_rnap) * scale
+
+    return xyz_sub, xyz_rnap
+
+
+__all__ = ["icos"]
+

--- a/src/smap_tools_python/make_template_stack.py
+++ b/src/smap_tools_python/make_template_stack.py
@@ -1,0 +1,52 @@
+import numpy as np
+from .ccf import ccf
+from .max_interp_f import max_interp_f
+from .phase_shift import apply_phase_shifts
+from .crop_pad import extendj, cutj
+
+
+def make_template_stack(nf_im, templates=None, ref_template_stack=None):
+    """Align templates to an image and return their stack and sum.
+
+    Parameters
+    ----------
+    nf_im : ndarray
+        The noise-filtered image used for alignment.
+    templates : ndarray, optional
+        Stack of templates with shape ``(M, N, K)``.
+    ref_template_stack : ndarray, optional
+        Reference stack to provide initial alignment coordinates.
+
+    Returns
+    -------
+    tuple of (ndarray, ndarray)
+        ``ti`` is the summed template image and ``template_im`` contains the
+        individual aligned templates.
+    """
+    nf_im = np.asarray(nf_im, dtype=float)
+    if templates is None:
+        return np.zeros_like(nf_im), np.zeros(nf_im.shape + (0,), dtype=float)
+
+    templates = np.asarray(templates, dtype=float)
+    pad_val = np.nanmedian(templates)
+    ti = np.ones_like(nf_im, dtype=float) * pad_val
+    template_im = np.ones(nf_im.shape + (templates.shape[2],), dtype=float) * pad_val
+
+    for j in range(templates.shape[2]):
+        temp = templates[:, :, j]
+        if ref_template_stack is None:
+            cc, _ = ccf(nf_im, temp[:, :, None])
+            cc = cc[:, :, 0]
+        else:
+            cc, _ = ccf(nf_im, ref_template_stack[:, :, j][:, :, None])
+            cc = cc[:, :, 0]
+        yt, xt = np.unravel_index(np.argmax(cc), cc.shape)
+        shifts, _ = max_interp_f(cc, 10, 20, (yt, xt))
+        padded = extendj(temp, (2048, 2048), pad_val)
+        shifted = apply_phase_shifts(padded, shifts)
+        template_im[:, :, j] = cutj(shifted, (nf_im.shape[0], nf_im.shape[1]))
+        ti += template_im[:, :, j]
+
+    return ti, template_im
+
+__all__ = ["make_template_stack"]

--- a/src/smap_tools_python/motion_corr.py
+++ b/src/smap_tools_python/motion_corr.py
@@ -1,0 +1,59 @@
+import numpy as np
+from numpy.fft import fftn, ifftn
+from scipy.ndimage import fourier_shift
+
+
+def _phase_correlation(ref, mov):
+    """Estimate translation between ``ref`` and ``mov`` via phase correlation."""
+    f_ref = fftn(ref)
+    f_mov = fftn(mov)
+    cross = f_ref * f_mov.conj()
+    cross /= np.maximum(np.abs(cross), 1e-9)
+    r = np.fft.fftshift(ifftn(cross))
+    max_idx = np.unravel_index(np.argmax(np.abs(r)), r.shape)
+    max_idx = np.array(max_idx, dtype=float)
+    mid = np.array(ref.shape) // 2
+    shifts = max_idx - mid
+    shifts[shifts > mid] -= np.array(ref.shape)[shifts > mid]
+    return shifts
+
+
+def motion_corr(frames, ref_index=None, axis=0):
+    """Align movie frames by translational phase correlation.
+
+    Parameters
+    ----------
+    frames : ndarray
+        Stack of movie frames.
+    ref_index : int, optional
+        Index of the reference frame; defaults to the middle frame.
+    axis : int, optional
+        Axis corresponding to the frame index.
+
+    Returns
+    -------
+    corrected : ndarray
+        Motion-corrected stack with the same shape as ``frames``.
+    shifts : ndarray
+        Array of per-frame ``(dy, dx)`` shifts that were applied.
+    """
+    frames = np.asarray(frames)
+    if frames.ndim != 3:
+        raise ValueError("expected a 3D stack of frames")
+    frames = np.moveaxis(frames, axis, 0)
+    n, h, w = frames.shape
+    if ref_index is None:
+        ref_index = n // 2
+    ref = frames[ref_index]
+    corrected = np.empty_like(frames, dtype=float)
+    shifts = np.zeros((n, 2), dtype=float)
+    for i, frame in enumerate(frames):
+        shift = _phase_correlation(ref, frame)
+        shifted = ifftn(fourier_shift(fftn(frame), shift)).real
+        corrected[i] = shifted
+        shifts[i] = shift
+    corrected = np.moveaxis(corrected, 0, axis)
+    return corrected, shifts
+
+
+__all__ = ["motion_corr"]

--- a/src/smap_tools_python/particle_diameter.py
+++ b/src/smap_tools_python/particle_diameter.py
@@ -1,7 +1,6 @@
 import numpy as np
 
 
-
 def particle_diameter(vol, thresh=0.005):
     """Estimate particle diameter from a 3-D volume.
 
@@ -27,3 +26,6 @@ def particle_diameter(vol, thresh=0.005):
         return 0.0
     max_r = r[mask].max()
     return float(2 * max_r)
+
+
+__all__ = ["particle_diameter"]

--- a/src/smap_tools_python/pdb2ep.py
+++ b/src/smap_tools_python/pdb2ep.py
@@ -1,0 +1,104 @@
+import os
+import subprocess
+from datetime import datetime
+
+
+def pdb2ep(pdb_path, nm_per_voxel, out_dir, tem_simulator="TEM-simulator"):
+    """Generate electrostatic potential from a PDB file using TEM-simulator.
+
+    The function prepares the configuration and auxiliary files required by the
+    external ``TEM-simulator`` program.  If the simulator binary is available it
+    is invoked; otherwise the configuration files are still written and the
+    expected output filename is returned.
+
+    Parameters
+    ----------
+    pdb_path : str
+        Path to the input PDB file.
+    nm_per_voxel : float
+        Desired voxel size for the output potential in nanometres.
+    out_dir : str
+        Directory where the configuration files and output map should reside.
+    tem_simulator : str, optional
+        Executable used to perform the conversion.  Defaults to
+        ``"TEM-simulator"``.
+
+    Returns
+    -------
+    str
+        Path to the expected electrostatic potential MRC file.
+    """
+
+    os.makedirs(out_dir, exist_ok=True)
+    pdb_path = os.path.abspath(pdb_path)
+    model_name = os.path.splitext(os.path.basename(pdb_path))[0]
+
+    config_path = os.path.join(out_dir, f"{model_name}_PDB2EP.txt")
+    log_line = f"log_file = {model_name}_{datetime.now():%Y%m%dT%H%M%S}.log"
+    lines = [
+        "=== simulation ===",
+        "generate_micrographs = yes",
+        log_line,
+        "",
+        "=== sample ===",
+        "diameter = 300",
+        "thickness_center = 0",
+        "thickness_edge = 0",
+        "",
+        "=== particle arb ===",
+        "source = pdb",
+        f"pdb_file_in = {pdb_path}",
+        "add_hydrogen = no",
+        f"voxel_size = {nm_per_voxel}",
+        f"map_file_re_out = {model_name}_EP.mrc",
+        "",
+        "=== particleset ===",
+        "particle_type = arb",
+        "particle_coords = file",
+        "coord_file_in = arb_location.txt",
+        "",
+        "=== geometry ===",
+        "gen_tilt_data = yes",
+        "tilt_mode = single_particle",
+        "geom_file_in = arb_rotations.txt",
+        "ntilts = 1",
+        "theta_start = 0",
+        "theta_incr = 0",
+        "",
+        "=== electronbeam ===",
+        "acc_voltage = 300",
+        "gen_dose = yes",
+        "dose_per_im = 1000",
+        "",
+        "=== optics ===",
+        "cs = 2.7",
+        "cond_ap_angle = 0.00",
+        "gen_defocus = yes",
+        "defocus_nominal = 0.07",
+        "",
+        "=== detector ===",
+        "det_pix_x = 512",
+        "det_pix_y = 512",
+        "pixel_size = 5",
+        "gain = 1",
+        "image_file_out = trash.mrc",
+    ]
+    with open(config_path, "w") as fh:
+        fh.write("\n".join(lines))
+
+    # coordinate and rotation files
+    with open(os.path.join(out_dir, "arb_location.txt"), "w") as fh:
+        fh.write("1  6\n#\t x\t y\t z\t phi\t theta\t psi\n\t0\t0\t0\t0\t0\t0\n")
+    with open(os.path.join(out_dir, "arb_rotations.txt"), "w") as fh:
+        fh.write("1  3\n#\t phi\t theta\t psi\n\t0\t0\t0\n")
+
+    try:
+        subprocess.run([tem_simulator, config_path], check=True)
+    except (OSError, FileNotFoundError):
+        # simulator not available; proceed without running it
+        pass
+
+    return os.path.join(out_dir, f"{model_name}_EP.mrc")
+
+
+__all__ = ["pdb2ep"]

--- a/src/smap_tools_python/preprocess.py
+++ b/src/smap_tools_python/preprocess.py
@@ -1,0 +1,28 @@
+
+def preprocess(obj):
+    """Run the standard SMAP preprocessing pipeline.
+
+    The ``obj`` argument is updated in-place by sequentially applying gain
+    correction, motion correction, frame summation, and CTF estimation if the
+    corresponding steps have not yet been performed (as indicated by flags in
+    ``obj.ID``).
+    """
+    from .gain_corr import gain_corr
+    from .sum_frames import sum_frames
+    from .run_ctffind import run_ctffind
+    try:  # optional dependency
+        from .motion_corr import motion_corr  # type: ignore
+    except Exception:  # pragma: no cover - motion correction may not be available
+        motion_corr = None
+
+    steps = ["GC", "MC", "SF", "CTF"]
+    calls = [gain_corr, motion_corr, sum_frames, run_ctffind]
+    for flag, func in zip(steps, calls):
+        if func is None:
+            continue
+        if not getattr(obj.ID, flag, False):
+            obj = func(obj)
+    return obj
+
+
+__all__ = ["preprocess"]

--- a/src/smap_tools_python/read_dm_file.py
+++ b/src/smap_tools_python/read_dm_file.py
@@ -1,0 +1,48 @@
+"""Read Digital Micrograph DM3/DM4 files.
+
+This is a lightweight translation of SMAP's ``ReadDMFile`` MATLAB helper
+which extracts the image stack along with pixel size information.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Tuple
+import numpy as np
+
+try:  # pragma: no cover - optional dependency
+    from ncempy.io import dm
+except Exception:  # pragma: no cover
+    dm = None  # type: ignore
+
+
+def read_dm_file(path: str | Path) -> Tuple[np.ndarray, Tuple[float, float], str]:
+    """Load a DM3/DM4 file using :mod:`ncempy`.
+
+    Parameters
+    ----------
+    path : str or :class:`~pathlib.Path`
+        Input filename.
+
+    Returns
+    -------
+    tuple
+        ``(data, pixel_size, units)`` where ``data`` is a ``numpy.ndarray``,
+        ``pixel_size`` is a two element tuple giving the pixel spacing
+        in nanometers and ``units`` is the raw unit string stored in the
+        file metadata.
+    """
+    if dm is None:  # pragma: no cover
+        raise ImportError("ncempy is required to read DM files")
+
+    result = dm.dmReader(str(path))
+    data = np.asarray(result["data"])
+    px = result.get("pixelSize", (1.0, 1.0))
+    units = result.get("pixelUnit", "")
+
+    # ncempy returns pixel size in meters; convert to nanometers
+    if np.isscalar(px):
+        px_nm = (float(px) * 1e9, float(px) * 1e9)
+    else:
+        px_nm = tuple(float(v) * 1e9 for v in np.atleast_1d(px)[:2])
+
+    return data, px_nm, str(units)

--- a/src/smap_tools_python/ri.py
+++ b/src/smap_tools_python/ri.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import numpy as np
 
 from .mrc import read_mrc
+from .read_dm_file import read_dm_file
 
 try:  # pragma: no cover - optional dependency
     import tifffile
@@ -104,6 +105,9 @@ def ri(filename: str | Path):
     if ext == ".mrc":
         data, voxel = read_mrc(str(path))
         return data, {"voxel_size": voxel}
-    if ext == ".dm4":  # pragma: no cover - not yet implemented
-        raise NotImplementedError("DM4 reading not implemented")
+    if ext in (".dm3", ".dm4"):
+        data, px, units = read_dm_file(path)
+        info = {"voxel_size": (px[0] * 10, px[1] * 10, px[0] * 10), "units": units}
+        # convert nm to angstroms for voxel_size
+        return data, info
     raise ValueError(f"Unknown file type: {ext}")

--- a/src/smap_tools_python/run_ctffind.py
+++ b/src/smap_tools_python/run_ctffind.py
@@ -1,0 +1,45 @@
+import subprocess
+from pathlib import Path
+
+
+def run_ctffind(obj):
+    """Run the external *ctffind* program using parameters from ``obj``.
+
+    The input ``obj`` is expected to be a mapping or object with ``CTF`` and
+    ``proc`` attributes/keys mirroring the MATLAB structure. The function writes
+    the parameter file, executes ``ctffind`` and parses the diagnostic output to
+    populate ``obj['final']`` and ``obj['ID']`` entries.
+    """
+    # support both attribute and dict style access
+    ctf_params = getattr(obj, "CTF", obj["CTF"])
+    proc = getattr(obj, "proc", obj["proc"])
+    out = getattr(obj, "final", obj.setdefault("final", {}))
+    ident = getattr(obj, "ID", obj.setdefault("ID", {}))
+
+    # write the parameter file expected by ctffind
+    params = {}
+    for key, val in ctf_params.items():
+        params[key] = str(val)
+    base = Path(proc["fullSum_image"])
+    fn_out = base.with_name(base.stem + "_CTFFind_input.txt")
+    with open(fn_out, "w") as fh:
+        for k, v in params.items():
+            fh.write(f"{k} {v}\n")
+
+    # execute ctffind
+    subprocess.run(["ctffind", str(fn_out)], check=True)
+
+    # read diagnostic output
+    diag_base = Path(ctf_params["output_diag_filename"])
+    diag_fn = diag_base.with_suffix(".txt")
+    with open(diag_fn, "r") as fh:
+        lines = fh.readlines()[5:12]
+    vals = [float(line.split()[0]) for line in lines[:7]]
+
+    out["df1"] = vals[1] / 10.0
+    out["df2"] = vals[2] / 10.0
+    out["ast"] = vals[3] * 3.141592653589793 / 180.0
+    ident["CTF"] = 1
+    return obj
+
+__all__ = ["run_ctffind"]

--- a/src/smap_tools_python/templates.py
+++ b/src/smap_tools_python/templates.py
@@ -1,0 +1,83 @@
+import numpy as np
+from scipy.ndimage import affine_transform
+from .crop_pad import extendj
+from .ctf import ctf
+from .constants import def_consts
+
+
+def _rotate_volume(vol, R):
+    center = (np.array(vol.shape) - 1) / 2.0
+    return affine_transform(
+        vol,
+        R.T,
+        offset=center - R.T @ center,
+        order=1,
+        mode="constant",
+        cval=float(np.median(vol)),
+    )
+
+
+def templates(volume, rotations, dfs=None, pixel_size=1.0, edge_size=None, params=None):
+    """Generate projection templates from a scattering potential volume.
+
+    Parameters
+    ----------
+    volume : ndarray, shape (Z, Y, X)
+        Scattering potential volume.
+    rotations : ndarray, shape (3, 3, N)
+        Rotation matrices describing template orientations.
+    dfs : array_like, shape (N, 3), optional
+        Defocus triplets ``(df1, df2, ast)`` in nanometers. A single row can be
+        provided and will be broadcast to all orientations. If ``None``, no CTF
+        is applied.
+    pixel_size : float, optional
+        Pixel size in Angstroms used for CTF generation. Default is ``1.0``.
+    edge_size : int, optional
+        Output template size. Defaults to ``volume.shape[0]``.
+    params : dict, optional
+        Microscope parameters to pass to :func:`ctf`. Missing values default to
+        those from :func:`def_consts`.
+
+    Returns
+    -------
+    ndarray
+        Stack of 2-D templates with shape ``(edge_size, edge_size, N)``.
+    """
+    vol = np.asarray(volume, dtype=float)
+    rot = np.asarray(rotations, dtype=float)
+    n_templates = rot.shape[2]
+
+    if edge_size is None:
+        edge_size = vol.shape[0]
+
+    if dfs is None:
+        dfs = np.zeros((n_templates, 3), dtype=float)
+        use_ctf = False
+    else:
+        dfs = np.atleast_2d(np.asarray(dfs, dtype=float))
+        if dfs.shape[0] == 1 and n_templates > 1:
+            dfs = np.repeat(dfs, n_templates, axis=0)
+        if dfs.shape[0] != n_templates:
+            raise ValueError("dfs must have shape (N,3) or (1,3)")
+        use_ctf = True
+
+    if params is None:
+        params = def_consts()
+    params = dict(params)
+    params.setdefault("aPerPix", pixel_size)
+
+    out = np.empty((edge_size, edge_size, n_templates), dtype=float)
+    for i in range(n_templates):
+        vol_rot = _rotate_volume(vol, rot[:, :, i])
+        proj = vol_rot.sum(axis=2)
+        proj = extendj(proj, (edge_size, edge_size), np.median(proj))
+        if use_ctf:
+            ctf_img = np.real(ctf(dfs[i], edge_size, params))
+            proj_F = np.fft.fftn(np.fft.ifftshift(proj))
+            proj = np.real(np.fft.fftshift(np.fft.ifftn(proj_F * ctf_img)))
+        out[:, :, i] = proj
+
+    return out
+
+
+__all__ = ["templates"]

--- a/src/smap_tools_python/templates_gpu.py
+++ b/src/smap_tools_python/templates_gpu.py
@@ -1,0 +1,34 @@
+import numpy as np
+
+from .templates import templates
+
+
+def templates_gpu(volume, rotations, dfs=None, pixel_size=1.0, edge_size=None, params=None):
+    """Generate projection templates and return them on the GPU when possible.
+
+    This is a lightweight wrapper around :func:`templates` that transfers the
+    resulting stack to CuPy when available. If CuPy is not installed, the CPU
+    result is returned unchanged.
+    """
+    out = templates(volume, rotations, dfs, pixel_size, edge_size, params)
+    try:
+        import cupy as cp  # type: ignore
+
+        return cp.asarray(out)
+    except Exception:  # pragma: no cover - CuPy may be absent
+        return out
+
+
+def templates_half_gpu(volume, rotations, dfs=None, pixel_size=1.0, edge_size=None, params=None):
+    """Generate templates at full resolution and downsample by two.
+
+    The computation is delegated to :func:`templates_gpu`; the returned stack is
+    decimated by taking every other pixel in both dimensions. This mimics the
+    MATLAB ``templates_half_gpu`` helper that produced half-sized templates for
+    coarse searches.
+    """
+    full = templates_gpu(volume, rotations, dfs, pixel_size, edge_size, params)
+    return full[::2, ::2]
+
+
+__all__ = ["templates_gpu", "templates_half_gpu"]

--- a/src/smap_tools_python/write_mrc_header.py
+++ b/src/smap_tools_python/write_mrc_header.py
@@ -1,0 +1,56 @@
+import numpy as np
+
+
+def write_mrc_header(map_array, voxel_size, filename, n_images=None):
+    """Write an MRC header and return an open file handle.
+
+    Parameters
+    ----------
+    map_array : array-like
+        Sample data whose shape and statistics populate the header.
+    voxel_size : float
+        Voxel size in ångström.
+    filename : str
+        Output file path.
+    n_images : int, optional
+        Number of sections expected in the file. Defaults to the third
+        dimension of ``map_array``.
+
+    Returns
+    -------
+    file object
+        Handle positioned after the 1024-byte header ready for sequential
+        writes.
+    """
+
+    arr = np.asarray(map_array, dtype=np.float32)
+    sizes = list(arr.shape)
+    if len(sizes) < 3:
+        sizes += [1] * (3 - len(sizes))
+    if n_images is not None:
+        sizes[2] = int(n_images)
+
+    hdr = np.zeros(256, dtype=np.int32)
+    hdr[0:3] = sizes  # dimensions
+    hdr[3] = 2  # mode 2 = float32
+    hdr[7:10] = sizes  # number of intervals
+
+    def _flt(val):
+        return np.asarray(val, dtype=np.float32).view(np.int32)
+
+    hdr[10:13] = _flt(np.array(sizes, dtype=np.float32) * float(voxel_size))
+    hdr[13:16] = _flt([90.0, 90.0, 90.0])
+    hdr[16:19] = [1, 2, 3]
+    stats = [arr.min(), arr.max(), arr.mean()]
+    hdr[19:22] = _flt(stats)
+    hdr[22] = 0
+    hdr[52] = int.from_bytes(b"MAP ", "little")
+    hdr[53] = int.from_bytes(bytes([68, 65, 0, 0]), "little")
+    hdr[54] = _flt(arr.std())
+
+    handle = open(filename, "wb")
+    hdr.tofile(handle)
+    return handle
+
+
+__all__ = ["write_mrc_header"]

--- a/tests/test_backproject.py
+++ b/tests/test_backproject.py
@@ -1,0 +1,20 @@
+import numpy as np
+from smap_tools_python import backproject
+
+
+def test_backproject_identity_slice():
+    patch = np.array([[1, 2], [3, 4]], float)
+    patches = patch[:, :, None]
+    R = np.eye(3)[None, ...]
+    vol = backproject(patches, R, pad_size=4)
+    expected = np.array(
+        [
+            [2.5, 2.5, 2.5, 2.5],
+            [2.5, 1.0, 2.0, 2.5],
+            [2.5, 3.0, 4.0, 2.5],
+            [2.5, 2.5, 2.5, 2.5],
+        ]
+    )
+    assert np.allclose(vol[:, :, 2], expected)
+    assert np.allclose(vol[:, :, :2], 0)
+    assert np.allclose(vol[:, :, 3], 0)

--- a/tests/test_ccff.py
+++ b/tests/test_ccff.py
@@ -1,0 +1,13 @@
+import numpy as np
+from smap_tools_python import ccff
+
+
+def test_ccff_peak():
+    rng = np.random.default_rng(0)
+    image = rng.normal(size=(8, 8))
+    templates = np.stack([image.copy(), rng.normal(size=(8, 8))], axis=-1)
+    cc, peaks = ccff(image, templates, mode="noFilt")
+    assert cc.shape == (8, 8, 2)
+    assert peaks[0] > peaks[1]
+    max_pos = np.unravel_index(np.argmax(cc[:, :, 0]), (8, 8))
+    assert max_pos == (4, 4)

--- a/tests/test_ccff_bak.py
+++ b/tests/test_ccff_bak.py
@@ -1,0 +1,12 @@
+import numpy as np
+from smap_tools_python import ccff, ccff_bak_041423
+
+
+def test_ccff_bak_equivalence():
+    rng = np.random.default_rng(0)
+    image = rng.normal(size=(8, 8))
+    templates = np.stack([image.copy(), rng.normal(size=(8, 8))], axis=-1)
+    cc1, peaks1 = ccff(image, templates, mode="noFilt")
+    cc2, peaks2 = ccff_bak_041423(image, templates, mode="noFilt")
+    assert np.allclose(cc1, cc2)
+    assert np.allclose(peaks1, peaks2)

--- a/tests/test_ccff_gpu.py
+++ b/tests/test_ccff_gpu.py
@@ -1,0 +1,12 @@
+import numpy as np
+from smap_tools_python import ccff_gpu, ccff
+
+
+def test_ccff_gpu_matches_cpu():
+    rng = np.random.default_rng(0)
+    im = rng.standard_normal((16, 16))
+    temps = rng.standard_normal((16, 16, 2))
+    out_gpu, peaks_gpu = ccff_gpu(im, temps)
+    out_cpu, peaks_cpu = ccff(im, temps)
+    assert np.allclose(out_gpu, out_cpu)
+    assert np.allclose(peaks_gpu, peaks_cpu)

--- a/tests/test_ccfn_ccfv.py
+++ b/tests/test_ccfn_ccfv.py
@@ -1,0 +1,24 @@
+import numpy as np
+from smap_tools_python import ccfn, ccfv
+
+
+def test_ccfn_peak():
+    rng = np.random.default_rng(0)
+    image = rng.normal(size=(8, 8))
+    templates = np.stack([image.copy(), rng.normal(size=(8, 8))], axis=-1)
+    cc, peaks = ccfn(image, templates)
+    assert cc.shape == (8, 8, 2)
+    assert peaks[0] > peaks[1]
+    max_pos = np.unravel_index(np.argmax(cc[:, :, 0]), (8, 8))
+    assert max_pos == (4, 4)
+
+
+def test_ccfv_peak():
+    rng = np.random.default_rng(0)
+    image = rng.normal(size=(8, 8))
+    templates = np.stack([image.copy(), rng.normal(size=(8, 8))], axis=-1)
+    cc, peaks = ccfv(image, templates)
+    assert cc.shape == (8, 8, 2)
+    assert peaks[0] > peaks[1]
+    max_pos = np.unravel_index(np.argmax(cc[:, :, 0]), (8, 8))
+    assert max_pos == (4, 4)

--- a/tests/test_ep2sp.py
+++ b/tests/test_ep2sp.py
@@ -1,0 +1,15 @@
+import numpy as np
+
+from smap_tools_python import ep2sp, def_consts
+
+
+def test_ep2sp_center_value():
+    vol = np.zeros((4, 4, 4), float)
+    vol[2, 2, 2] = 2.0
+    sp, a = ep2sp(vol, 1.0, 1.0)
+    assert sp.shape == (4, 4, 4)
+    consts = def_consts()
+    scale = consts["IC"] * (10.0 / 1e10) / (2 * consts["k"])
+    assert np.isclose(sp[2, 2, 2], 2.0 * scale)
+    assert sp.dtype == np.float32
+    assert np.isclose(a, 10.0)

--- a/tests/test_estimate_detector.py
+++ b/tests/test_estimate_detector.py
@@ -1,0 +1,20 @@
+import numpy as np
+from pathlib import Path
+
+from smap_tools_python import estimate_detector
+from smap_tools_python.mrc import write_mrc
+
+
+def test_estimate_detector_runs(tmp_path: Path):
+    # Create a few random micrographs
+    files = []
+    for i in range(3):
+        arr = np.random.randn(32, 32).astype(np.float32)
+        fn = tmp_path / f"frame_{i}.mrc"
+        write_mrc(fn, arr[None, :, :], 1.0)
+        files.append(str(fn))
+
+    filt = estimate_detector(files)
+    assert filt.ndim == 1
+    assert np.isfinite(filt).all()
+    assert len(filt) > 10

--- a/tests/test_gain_corr.py
+++ b/tests/test_gain_corr.py
@@ -1,0 +1,13 @@
+import numpy as np
+from smap_tools_python import gain_corr
+
+
+def test_gain_corr_hot_pixel():
+    rng = np.random.default_rng(0)
+    movie = rng.normal(size=(8, 8, 5))
+    gain = np.ones((8, 8))
+    movie[2, 3, :] += 100  # introduce hot pixel
+    corrected, hot = gain_corr(movie, gain, hot_threshold=5)
+    assert corrected.shape == movie.shape
+    assert [2, 3] in hot.tolist()
+    assert corrected[2, 3, 0] < 50

--- a/tests/test_icos.py
+++ b/tests/test_icos.py
@@ -1,0 +1,29 @@
+import numpy as np
+from scipy.spatial.transform import Rotation
+
+from smap_tools_python import icos, get_icos
+
+
+def test_icos_shapes_and_radius():
+    xyz_sub, xyz_rnap = icos()
+    assert xyz_sub.shape == (60, 3)
+    assert xyz_rnap.shape == (60, 3)
+
+    radii = np.linalg.norm(xyz_sub, axis=1)
+    assert np.allclose(radii, radii[0])
+    assert np.isclose(radii[0], 1.0, atol=1e-6)
+
+
+def test_get_icos_identity_matches_group():
+    q_out, xyz_sub, xyz_rnap = get_icos([0, 0, 0, 1])
+    assert q_out.shape == (60, 4)
+
+    ops = Rotation.create_group("I")
+    np.testing.assert_allclose(
+        Rotation.from_quat(q_out).as_matrix(), ops.as_matrix()
+    )
+
+    xyz_sub_base, xyz_rnap_base = icos()
+    np.testing.assert_allclose(xyz_sub, xyz_sub_base)
+    np.testing.assert_allclose(xyz_rnap, xyz_rnap_base)
+

--- a/tests/test_motion_corr.py
+++ b/tests/test_motion_corr.py
@@ -1,0 +1,20 @@
+import numpy as np
+from numpy.fft import fftn, ifftn
+from scipy.ndimage import fourier_shift
+
+from smap_tools_python.motion_corr import motion_corr
+
+
+def test_motion_corr_aligns_frames():
+    base = np.zeros((32, 32))
+    base[10:22, 8:20] = 1
+    shifts = [(0, 0), (1, -2), (-3, 2), (2, 1)]
+    frames = []
+    for sh in shifts:
+        shifted = ifftn(fourier_shift(fftn(base), sh)).real
+        frames.append(shifted)
+    movie = np.stack(frames, axis=0)
+    aligned, est = motion_corr(movie, ref_index=0, axis=0)
+    # after correction each frame should match the reference pattern
+    assert np.allclose(aligned, base, atol=1e-3)
+    assert np.allclose(est, -np.array(shifts), atol=0.5)

--- a/tests/test_pdb2ep.py
+++ b/tests/test_pdb2ep.py
@@ -1,0 +1,16 @@
+import os
+from smap_tools_python import pdb2ep
+
+
+def test_pdb2ep_writes_files(tmp_path):
+    pdb_file = tmp_path / "model.pdb"
+    pdb_file.write_text("HEADER test\nEND\n")
+    out_dir = tmp_path / "out"
+    ep_path = pdb2ep(str(pdb_file), 1.23, str(out_dir), tem_simulator="true")
+    cfg = out_dir / f"{pdb_file.stem}_PDB2EP.txt"
+    assert cfg.exists()
+    assert (out_dir / "arb_location.txt").exists()
+    assert (out_dir / "arb_rotations.txt").exists()
+    text = cfg.read_text()
+    assert f"pdb_file_in = {pdb_file}" in text
+    assert ep_path == str(out_dir / f"{pdb_file.stem}_EP.mrc")

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,0 +1,11 @@
+import numpy as np
+from smap_tools_python import templates
+
+
+def test_templates_identity_projection():
+    vol = np.zeros((8, 8, 8), dtype=float)
+    vol[3:5, 3:5, 3:5] = 1.0
+    rot = np.eye(3)[..., None]
+    tmpl = templates(vol, rot, dfs=None, pixel_size=1.0)
+    assert tmpl.shape == (8, 8, 1)
+    assert np.allclose(tmpl[:, :, 0], vol.sum(axis=2))

--- a/tests/test_templates_gpu_get_dots.py
+++ b/tests/test_templates_gpu_get_dots.py
@@ -1,0 +1,34 @@
+import numpy as np
+from scipy.spatial.transform import Rotation as Rot
+
+from smap_tools_python.templates import templates
+from smap_tools_python.templates_gpu import templates_gpu, templates_half_gpu
+from smap_tools_python.get_dots import get_dots
+
+
+def test_templates_gpu_matches_cpu():
+    vol = np.random.rand(8, 8, 8)
+    rots = np.repeat(np.eye(3)[:, :, None], 2, axis=2)
+    cpu = templates(vol, rots)
+    gpu = templates_gpu(vol, rots)
+    assert np.allclose(cpu, np.asarray(gpu))
+
+
+def test_templates_half_gpu_downsamples():
+    vol = np.random.rand(8, 8, 8)
+    rots = np.eye(3)[:, :, None]
+    full = templates_gpu(vol, rots)
+    half = templates_half_gpu(vol, rots)
+    assert half.shape[0] * 2 == full.shape[0]
+    assert np.allclose(full[::2, ::2, 0], np.asarray(half)[:, :, 0])
+
+
+def test_get_dots_reproducible():
+    vol = np.zeros((16, 16, 16), float)
+    x = np.arange(16) - 7.5
+    X, Y, Z = np.meshgrid(x, x, x, indexing="ij")
+    vol[(X ** 2 + Y ** 2 + Z ** 2) <= 4 ** 2] = 1.0
+    rots = Rot.random(40, random_state=0).as_matrix().transpose(1, 2, 0)
+    mean, std = get_dots(vol, rots, df=None, edge_size=16, n_samples=20)
+    assert np.isclose(mean, 1.1897957200252536)
+    assert np.isclose(std, 0.040022920317379196)


### PR DESCRIPTION
## Summary
- convert electrostatic potential volumes to scattering potential with resizing, padding, and phase adjustments
- generate TEM-simulator configuration files to build electrostatic potentials from PDB models
- provide a simple real-space backprojection routine for combining rotated projection stacks
- expose run_ctffind, template stack alignment, DM3/DM4 reading, dose filtering, and GPU template helpers at the package root
- provide a legacy `ccff_bak_041423` wrapper for backward compatibility

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68bdd8f30abc832899b53a9bac9d5645