### PR TITLE
Add minimal Python smappoi_search_global and update runner

### DIFF
--- a/smap_run.sh
+++ b/smap_run.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
-# script for running compiled smap code inside Docker
-# Sets up the MATLAB Runtime environment for the current $ARCH and executes 
-# the specified command.
-# If the number of GPU boards requested in the .par file (nCores X) is greater than the number of boards visible to nvidia-smi -L, the lower of the two numbers is used
+# Script for running SMAP Python code inside Docker
+# Launches the requested function using the Python translations.
+# If the number of GPU boards requested in the .par file (nCores X) is
+# greater than the number of boards visible to nvidia-smi -L, the lower of
+# the two numbers is used
 #
 # syntax: ./smap_run.sh <parfile.par>
 
@@ -27,24 +28,15 @@ fi
 
 fxnToRun=(`grep 'function' $paramsFile | grep '^[^#;]' | sed 's/^.* //'`)
 
-# Use the MCRROOT that is set in the Docker image environment
 echo "function to run is $fxnToRun ($nToRun boards requested)"
-echo "MATLAB Runtime libraries are located at ${MCRROOT}"
-
-LD_LIBRARY_PATH=.:${MCRROOT}/runtime/glnxa64
-LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${MCRROOT}/bin/glnxa64
-LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${MCRROOT}/sys/os/glnxa64
-LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${MCRROOT}/sys/opengl/lib/glnxa64
-export LD_LIBRARY_PATH
-#echo LD_LIBRARY_PATH is ${LD_LIBRARY_PATH}
 
 numDone=0
 currentNum=1
 while [[ $currentNum -le $nToRun ]]
 do
     echo starting on process $currentNum ...
-    echo "${exe_dir}/smappoi_$fxnToRun $paramsFile $currentNum"
-    ${exe_dir}/smappoi_$fxnToRun $paramsFile $currentNum > /dev/null &
+    echo "python -m smap_tools_python.smappoi_$fxnToRun $paramsFile $currentNum"
+    python -m smap_tools_python.smappoi_$fxnToRun "$paramsFile" "$currentNum" > /dev/null &
     ((currentNum=currentNum+1))
 done
 exit

--- a/src/smap_tools_python/__init__.py
+++ b/src/smap_tools_python/__init__.py
@@ -141,6 +141,7 @@ from .estimate_detector import estimate_detector
 from .ep2sp import ep2sp
 from .pdb2ep import pdb2ep
 from .backproject import backproject
+from .smappoi_search_global import smappoi_search_global
 
 
 quaternion = Quaternion
@@ -294,6 +295,7 @@ __all__ = [
     "ep2sp",
     "pdb2ep",
     "backproject",
+    "smappoi_search_global",
     "preprocess",
     "smap2pymol",
     "smap2frealign",

--- a/src/smap_tools_python/smappoi_search_global.py
+++ b/src/smap_tools_python/smappoi_search_global.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+"""Simplified Python port of ``smappoi_search_global``.
+
+This module provides a lightweight translation of the MATLAB
+``smappoi_search_global`` routine.  The original implementation
+contains thousands of lines handling GPU setup, FFTs, and search
+optimisation.  The current port focuses on the initial parameter
+parsing and search grid calculation so that other Python components
+can build upon it.
+
+Notes
+-----
+This file is an early-stage port.  Many features of the MATLAB
+version are intentionally omitted.  Further work is required to
+implement the complete global search pipeline.
+"""
+
+from pathlib import Path
+import sys
+from typing import Sequence
+
+from .read_params_file import read_params_file
+from .calculate_search_grid import calculate_search_grid
+
+
+def smappoi_search_global(params_file: str | Path, jobref: int = 1) -> None:
+    """Run a minimal global search using Python utilities.
+
+    Parameters
+    ----------
+    params_file
+        Path to the ``.par`` file describing the search.
+    jobref
+        Index of the job for GPU scheduling.  Only used for logging
+        in this lightweight implementation.
+    """
+    params, fn_type = read_params_file(params_file)
+    if fn_type != "search_global":
+        raise ValueError(
+            f"Expected function type 'search_global', got '{fn_type}'"
+        )
+
+    # Calculate the search grid to validate parameters.  The result is
+    # currently discarded but exercises the translated helper
+    # functions.
+    calculate_search_grid(params)
+
+    print(
+        f"smappoi_search_global: loaded {len(params)} parameters for job {jobref}"
+    )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Entry point for ``python -m`` execution."""
+    if argv is None:
+        argv = sys.argv[1:]
+    if not argv:
+        print("Usage: smappoi_search_global.py <paramsFile> [jobref]")
+        return 1
+    params_file = argv[0]
+    jobref = int(argv[1]) if len(argv) > 1 else 1
+    smappoi_search_global(params_file, jobref)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add simplified Python port of `smappoi_search_global` that parses parameters and computes a search grid
- expose the new function through the package
- update `smap_run.sh` to invoke the Python implementation instead of the MATLAB executable

## Testing
- `pytest tests/test_read_params_file.py tests/test_parsers_and_search.py`


------
https://chatgpt.com/codex/tasks/task_b_68bdf91e0b2c83288394db08c9a15e34