### PR TITLE
Add simplified smappoi_search_local port and tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pytest
 mrcfile
 openpyxl
 ncempy
+pandas

--- a/src/smap_tools_python/__init__.py
+++ b/src/smap_tools_python/__init__.py
@@ -142,6 +142,7 @@ from .ep2sp import ep2sp
 from .pdb2ep import pdb2ep
 from .backproject import backproject
 from .smappoi_search_global import smappoi_search_global
+from .smappoi_search_local import smappoi_search_local
 
 
 quaternion = Quaternion
@@ -296,6 +297,7 @@ __all__ = [
     "pdb2ep",
     "backproject",
     "smappoi_search_global",
+    "smappoi_search_local",
     "preprocess",
     "smap2pymol",
     "smap2frealign",

--- a/src/smap_tools_python/smappoi_search_local.py
+++ b/src/smap_tools_python/smappoi_search_local.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+"""Simplified Python port of ``smappoi_search_local``.
+
+This module focuses on parameter parsing and basic table / rotation
+handling so that other parts of the toolbox can build upon it.  The
+original MATLAB routine performs an extensive local correlation search;
+the current port only mirrors the initial I/O behaviour.
+"""
+
+from pathlib import Path
+from typing import Sequence, Tuple
+
+import numpy as np
+import pandas as pd
+
+from .read_params_file import read_params_file
+from .rotations_io import read_rotations_file
+
+
+def _load_table(params: dict) -> pd.DataFrame:
+    """Load particle/patch information from either a CSV table or a
+    coordinate file.
+
+    The MATLAB implementation supports multiple formats.  Here we handle
+    two common cases using :mod:`pandas` and :mod:`numpy`.
+    """
+
+    if params.get("tableFile"):
+        # Expect a CSV file with column headers.
+        return pd.read_csv(params["tableFile"])
+
+    if params.get("coordinateFile"):
+        data = np.loadtxt(params["coordinateFile"], ndmin=2)
+        # Use the first six columns which correspond to xyz and defocus
+        # parameters in the MATLAB code.
+        cols = ["x", "y", "z", "df1", "df2", "df3"]
+        data = data[:, : len(cols)]
+        return pd.DataFrame(data, columns=cols)
+
+    return pd.DataFrame()
+
+
+def smappoi_search_local(
+    params_file: str | Path, jobref: int = 1
+) -> Tuple[pd.DataFrame, np.ndarray]:
+    """Load parameters, rotations and particle tables for a local search.
+
+    Parameters
+    ----------
+    params_file
+        Path to the ``.par`` file describing the search.
+    jobref
+        Index of the job; only used for logging in this lightweight
+        implementation.
+
+    Returns
+    -------
+    table, rotations
+        ``table`` is the particle information as a :class:`~pandas.DataFrame`
+        and ``rotations`` is a ``(3,3,N)`` ``numpy.ndarray`` of rotation
+        matrices read from ``params.rotationsFile``.
+    """
+
+    params, fn_type = read_params_file(params_file)
+    if fn_type != "search_local":
+        raise ValueError(f"Expected function type 'search_local', got '{fn_type}'")
+
+    rot_file = params.get("rotationsFile")
+    rotations = (
+        read_rotations_file(rot_file) if rot_file else np.empty((3, 3, 0))
+    )
+
+    table = _load_table(params)
+
+    print(
+        f"smappoi_search_local: loaded {len(table)} entries and "
+        f"{rotations.shape[2]} rotations for job {jobref}"
+    )
+
+    return table, rotations
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Entry point for ``python -m`` execution."""
+    if argv is None:
+        import sys
+
+        argv = sys.argv[1:]
+    if not argv:
+        print("Usage: smappoi_search_local.py <paramsFile> [jobref]")
+        return 1
+    params_file = argv[0]
+    jobref = int(argv[1]) if len(argv) > 1 else 1
+    smappoi_search_local(params_file, jobref)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/tests/test_smappoi_search_local.py
+++ b/tests/test_smappoi_search_local.py
@@ -1,0 +1,28 @@
+import numpy as np
+import pandas as pd
+
+from smap_tools_python import write_rotations_file, smappoi_search_local
+
+
+def test_smappoi_search_local(tmp_path):
+    rot = np.stack([np.eye(3), np.eye(3)], axis=2)
+    rot_file = tmp_path / "rots.txt"
+    write_rotations_file(rot, rot_file)
+
+    table = pd.DataFrame({"fn_patches": ["p1.mrc", "p2.mrc"], "patches_pageref": [1, 2]})
+    table_file = tmp_path / "table.csv"
+    table.to_csv(table_file, index=False)
+
+    params_file = tmp_path / "params.par"
+    params_file.write_text(
+        f"""
+function search_local
+rotationsFile {rot_file}
+tableFile {table_file}
+"""
+    )
+
+    df, rotations = smappoi_search_local(params_file)
+    assert list(df.columns) == ["fn_patches", "patches_pageref"]
+    assert len(df) == 2
+    assert rotations.shape == (3, 3, 2)


### PR DESCRIPTION
## Summary
- add lightweight smappoi_search_local Python port that loads parameters, rotation matrices and particle tables
- expose smappoi_search_local in package API and add pandas dependency
- test local search table/rotation loading

## Testing
- `pytest` *(fails: 76 errors during collection)*
- `pytest tests/test_smappoi_search_local.py -q`

------
https://chatgpt.com/codex/tasks/task_b_68bdfc3daf588328a04cfb1ff797de22