### PR TITLE
Add placeholder Smap class

### DIFF
--- a/src/smap_tools_python/__init__.py
+++ b/src/smap_tools_python/__init__.py
@@ -1,5 +1,6 @@
 """Python utilities for SMAP tools."""
 
+from .smap import Smap
 from .cos_mask import cos_mask, variable_cos_mask, cosMask
 from .rrj import rrj
 from .quaternion import Quaternion
@@ -148,6 +149,7 @@ from .smappoi_search_local import smappoi_search_local
 quaternion = Quaternion
 
 __all__ = [
+    "Smap",
     "cos_mask",
     "variable_cos_mask",
     "cosMask",

--- a/src/smap_tools_python/smap.py
+++ b/src/smap_tools_python/smap.py
@@ -1,0 +1,29 @@
+"""Minimal placeholder class mirroring MATLAB's ``smap`` handle.
+
+The original MATLAB ``smap.m`` class is essentially a thin namespace that
+exposes many stand‑alone helper routines as static methods.  The Python port
+already provides those helpers as top‑level functions within the
+``smap_tools_python`` package.  For compatibility with existing scripts that
+expect an object, this module defines :class:`Smap`, which merely stores an
+optional ``prefs`` attribute.
+"""
+
+from dataclasses import dataclass
+from typing import Any, Optional
+
+
+@dataclass
+class Smap:
+    """Light‑weight container matching the MATLAB ``smap`` interface.
+
+    Parameters
+    ----------
+    prefs : Any, optional
+        User preference data to attach to the instance.  The class does not
+        interpret this value but stores it for convenience.
+    """
+
+    prefs: Optional[Any] = None
+
+
+__all__ = ["Smap"]

--- a/tests/test_smap.py
+++ b/tests/test_smap.py
@@ -1,0 +1,8 @@
+import smap_tools_python as stp
+
+
+def test_smap_placeholder_holds_prefs():
+    obj = stp.Smap()
+    assert obj.prefs is None
+    obj2 = stp.Smap({'alpha': 1})
+    assert obj2.prefs['alpha'] == 1


### PR DESCRIPTION
## Summary
- provide a minimal `Smap` class mirroring MATLAB's `smap` handle
- expose `Smap` through the package namespace
- add a regression test for the placeholder

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68bdfe8a41b48328bedb3dda4b60a38b