### PR TITLE
chore: fail CI on MATLAB files

### DIFF
--- a/.github/workflows/no_matlab_files.yml
+++ b/.github/workflows/no_matlab_files.yml
@@ -1,0 +1,17 @@
+name: Check for forbidden MATLAB files
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  no-matlab:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Fail if MATLAB backups or scripts are present
+        run: |
+          if git ls-files | grep -E -i '\.(m|asv)$'; then
+            echo 'MATLAB (.m) or backup (.asv) files detected. Remove them before committing.'
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow that fails if `.m` or `.asv` files are committed

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68be012c481c8328a9843ccb4690b7d5