### PR TITLE
Replace run_smappoi shell wrapper with Python launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ Dockerfile: used to rebuild a containerized environment on Ubuntu 22.04 systems 
 
 smap_run.sh: bash script to start a global search using the Python implementation. Syntax to run is `./smap_run.sh <your_parfile.par>`
 
-run_smappoi.sh: wrapper script that reads the requested function from a parameter file and runs the corresponding Python module
+run_smappoi.py: Python wrapper that reads the requested function from a parameter file and runs the corresponding module
 
 sample_search.par: sample parameter file
 
@@ -244,10 +244,10 @@ README.md: this readme file
 
 ## Usage
 
-To run a search using the Python implementation, execute the wrapper script with a parameter file:
+To run a search using the Python implementation inside Docker, execute `smap_run.sh` with a parameter file:
 
 ```bash
-./run_smappoi.sh sample_search.par
+./smap_run.sh sample_search.par
 ```
 
 This script reads the `function` entry from the parameter file and dispatches to the matching module, such as
@@ -256,7 +256,13 @@ This script reads the `function` entry from the parameter file and dispatches to
 python -m smap_tools_python.smappoi_search_global sample_search.par 1
 ```
 
-For multi-GPU runs, `smap_run.sh` uses the same approach to launch one process per GPU based on the `nCores` value in the parameter file.
+For single-run invocations outside the Docker wrapper you can also call:
+
+```bash
+python run_smappoi.py sample_search.par
+```
+
+`smap_run.sh` uses the same approach to launch one process per GPU based on the `nCores` value in the parameter file.
 
 
 ## INSTALLATION HINTS

--- a/run_smappoi.py
+++ b/run_smappoi.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Python wrapper for running SMAP modules based on parameter file."""
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Dispatch to the appropriate ``smappoi_*`` module.
+
+    Parameters
+    ----------
+    argv: list[str] | None
+        Command-line arguments. If ``None`` ``sys.argv[1:]`` is used.
+
+    Returns
+    -------
+    int
+        Exit status code.
+    """
+    if argv is None:
+        argv = sys.argv[1:]
+    if not argv:
+        print("Usage: run_smappoi.py <paramsFile> [boardIndex]")
+        return 1
+    params_file = Path(argv[0])
+    board = argv[1] if len(argv) > 1 else "1"
+
+    fxn_to_run: str | None = None
+    with params_file.open() as fh:
+        for line in fh:
+            line = line.strip()
+            if not line or line.startswith("#") or line.startswith(";"):
+                continue
+            if line.startswith("function"):
+                fxn_to_run = line.split()[-1]
+                break
+    if not fxn_to_run:
+        print(f"No function specified in {params_file}")
+        return 1
+
+    module_name = f"smap_tools_python.smappoi_{fxn_to_run}"
+    module = importlib.import_module(module_name)
+    if hasattr(module, "main"):
+        return module.main([str(params_file), board])
+    # Fallback to calling the function directly if ``main`` is missing
+    func = getattr(module, f"smappoi_{fxn_to_run}")
+    func(str(params_file), int(board))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/run_smappoi.sh
+++ b/run_smappoi.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-# Wrapper for running SMAP Python modules
-# usage: run_smappoi.sh <paramsFile> [boardIndex]
-paramsFile=$1
-board=${2:-1}
-fxnToRun=$(grep 'function' "$paramsFile" | grep '^[^#;]' | sed 's/^.* //')
-python -m smap_tools_python.smappoi_${fxnToRun} "$paramsFile" "$board"


### PR DESCRIPTION
## Summary
- remove the old `run_smappoi.sh` shell script
- add `run_smappoi.py` to dispatch to `smap_tools_python.smappoi_*`
- document using `smap_run.sh` and the new Python wrapper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68be07d951e08328ae09d080e27bff81