### PR TITLE
Add pre-commit check to prevent .asv files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 __pycache__/
 *.pyc
+
+# Ignore MATLAB autosave files
+*.asv

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+- repo: local
+  hooks:
+  - id: forbid-asv-files
+    name: Fail when .asv files are present
+    entry: "bash -c 'echo \"Error: .asv files are not allowed:\" \"$@\" >&2; exit 1'"
+    language: system
+    files: \.asv$
+    pass_filenames: true

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ mrcfile
 openpyxl
 ncempy
 pandas
+pre-commit


### PR DESCRIPTION
## Summary
- block committing of `.asv` autosave files via pre-commit hook
- ignore `.asv` files and include pre-commit in requirements

## Testing
- `pre-commit run --all-files`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68be0dabbc188328a25d89bb0d574579