### PR TITLE
Use Bio.PDB for structure parsing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ openpyxl
 ncempy
 pandas
 pre-commit
+biopython

--- a/src/smap_tools_python/pdb.py
+++ b/src/smap_tools_python/pdb.py
@@ -1,101 +1,99 @@
 from __future__ import annotations
 
+from pathlib import Path
+from typing import Any, Dict, List
+
 import numpy as np
-from typing import Dict, List, Any
+from Bio.PDB import MMCIFParser, PDBParser
+from Bio.PDB.MMCIF2Dict import MMCIF2Dict
+
+
+def _atom_record(atom):
+    """Return record type (ATOM/HETATM) for an atom."""
+    hetero_flag = atom.get_parent().id[0]
+    return "HETATM" if hetero_flag.strip() else "ATOM"
 
 
 def read_pdb_file(filename: str) -> Dict[str, Any]:
-    """Read an ASCII ``.pdb`` file.
+    """Read a PDB or mmCIF file using :mod:`Bio.PDB` utilities.
 
-    This is a lightweight parser that extracts atom records and a handful of
-    commonly used fields.  The return value mirrors MATLAB's ``read_pdb_file``
-    helper and provides a dictionary containing atom coordinates and assorted
-    metadata.
+    Parameters
+    ----------
+    filename:
+        Path to a ``.pdb`` or ``.cif``/``.mmcif`` file.
+
+    Returns
+    -------
+    dict
+        Dictionary containing coordinates, atom annotations and assorted
+        metadata mirroring the previous MATLAB helper.
     """
-    with open(filename, "r") as fh:
-        split_lines = fh.read().splitlines()
+    path = Path(filename)
+    split_lines = path.read_text().splitlines()
 
-    atom_list: List[str] = []
-    b_factor: List[float] = []
-    chain_ids: List[str] = []
-    res_name: List[str] = []
-    occ: List[float] = []
-    inds: List[int] = []
-    header: List[str] = []
-    header_inds: List[int] = []
-    line_type: List[int] = []
-    xyz: List[List[float]] = []
+    is_cif = path.suffix.lower() in {".cif", ".mmcif"}
+    parser = MMCIFParser(QUIET=True) if is_cif else PDBParser(QUIET=True)
+    structure = parser.get_structure(path.stem, filename)
+    metadata = MMCIF2Dict(filename) if is_cif else parser.get_header()
+
+    atoms = list(structure.get_atoms())
+    coords = np.asarray([a.coord for a in atoms], dtype=float)
+    xyz = coords.T if atoms else np.empty((3, 0))
+
+    atom_list = [a.get_name().strip() for a in atoms]
+    chain_ids = [a.get_parent().get_parent().id.strip() for a in atoms]
+    res_name = [a.get_parent().get_resname().strip() for a in atoms]
+    b_factor = [a.get_bfactor() for a in atoms]
+    occ = [a.get_occupancy() if a.get_occupancy() is not None else np.nan for a in atoms]
+    alt_loc = [a.get_altloc().strip() for a in atoms]
+    element = [a.element.strip() if a.element else "" for a in atoms]
 
     pdb_data = {
-        "atomType": [],
-        "atomNum": [],
-        "atomName": [],
-        "resName": [],
-        "chain": [],
-        "resNum": [],
-        "X": [],
-        "Y": [],
-        "Z": [],
-        "b_factor": [],
-        "comment": [],
-        "filler": [],
-        "occ": [],
+        "atomType": [_atom_record(a) for a in atoms],
+        "atomNum": [str(a.serial_number) for a in atoms],
+        "atomName": atom_list,
+        "resName": res_name,
+        "chain": chain_ids,
+        "resNum": [str(a.get_parent().id[1]) for a in atoms],
+        "filler": [""] * len(atoms),
+        "X": [f"{c[0]:8.3f}" for c in coords],
+        "Y": [f"{c[1]:8.3f}" for c in coords],
+        "Z": [f"{c[2]:8.3f}" for c in coords],
+        "occ": ["" if np.isnan(o) else f"{o:6.2f}" for o in occ],
+        "b_factor": [f"{b:6.2f}" for b in b_factor],
+        "comment": [""] * len(atoms),
+        "element": element,
+        "altLoc": alt_loc,
         "line": split_lines,
     }
 
+    header_inds: List[int] = []
+    header: List[str] = []
+    inds: List[int] = []
+    line_type: List[int] = []
     for idx, line in enumerate(split_lines, start=1):
-        record = line[0:6].strip()
-        if record in {"ATOM", "HETATM", "TER"}:
-            try:
-                pdb_data["atomType"].append(line[0:6])
-                pdb_data["atomNum"].append(line[6:11])
-                pdb_data["atomName"].append(line[12:16])
-                pdb_data["resName"].append(line[17:20])
-                pdb_data["chain"].append(line[21:22])
-                pdb_data["resNum"].append(line[22:26])
-                pdb_data["filler"].append(line[27:30])
-                pdb_data["X"].append(line[30:38])
-                pdb_data["Y"].append(line[38:46])
-                pdb_data["Z"].append(line[46:54])
-                pdb_data["occ"].append(line[54:60])
-                pdb_data["b_factor"].append(line[60:66])
-                pdb_data["comment"].append(line[66:])
-
-                x = float(line[30:38])
-                y = float(line[38:46])
-                z = float(line[46:54])
-                xyz.append([x, y, z])
-                atom_list.append(line[12:16].strip())
-                chain_ids.append(line[21:22].strip())
-                res_name.append(line[17:20].strip())
-                b_factor.append(float(line[60:66]))
-                occ.append(float(line[54:60]))
-                inds.append(idx)
-                line_type.append(1)
-            except ValueError:
-                header.append(line)
-                header_inds.append(idx)
-                line_type.append(0)
+        if line.startswith(("ATOM", "HETATM", "TER")):
+            inds.append(idx)
+            line_type.append(1)
         else:
-            header.append(line)
             header_inds.append(idx)
+            header.append(line)
             line_type.append(0)
 
-    xyz_arr = np.asarray(xyz, dtype=float).T if xyz else np.empty((3, 0))
-    b_factor_arr = np.asarray(b_factor, dtype=float)
-    occ_arr = np.asarray(occ, dtype=float)
-
     return {
-        "xyz": xyz_arr,
+        "xyz": xyz,
         "atomList": atom_list,
-        "bFactor": b_factor_arr,
+        "bFactor": np.asarray(b_factor, dtype=float),
         "chainIDs": chain_ids,
         "resName": res_name,
-        "occ": occ_arr,
+        "occ": np.asarray(occ, dtype=float),
+        "altLoc": alt_loc,
+        "element": element,
         "inds": inds,
         "header": header,
         "headerInds": header_inds,
         "lineType": line_type,
         "PDBdata": pdb_data,
         "splitLines": split_lines,
+        "metadata": metadata,
     }

--- a/tests/test_struct_io.py
+++ b/tests/test_struct_io.py
@@ -28,3 +28,30 @@ def test_read_pdb_file_basic():
     assert np.allclose(xyz[:, 0], [29.342, -33.809, -75.427])
     assert np.isclose(data["bFactor"][0], 142.22)
     assert np.isclose(data["occ"][0], 1.00)
+
+
+def test_read_pdb_file_mmcif():
+    cif_path = MODEL_DIR / "6ek0_LSU.cif"
+    data = read_pdb_file(str(cif_path))
+    xyz = data["xyz"]
+    assert xyz.shape[0] == 3
+    assert data["atomList"][0] == "C5'"
+    assert data["chainIDs"][0] == "L5"
+    assert np.allclose(xyz[:, 0], [-20.637, 30.989, 98.976])
+    assert np.isclose(data["bFactor"][0], 109.77)
+    assert np.isclose(data["occ"][0], 1.0)
+
+
+def test_read_pdb_file_altloc(tmp_path):
+    pdb_content = (
+        "ATOM      1  CA AASN A   1      11.104  13.207  10.718  0.50 20.00           C\n"
+        "ATOM      1  CA BASN A   1      11.204  13.307  10.818  0.50 25.00           C\n"
+        "TER\n"
+        "END\n"
+    )
+    pdb_path = tmp_path / "altloc.pdb"
+    pdb_path.write_text(pdb_content)
+    data = read_pdb_file(str(pdb_path))
+    assert np.allclose(data["xyz"][:, 0], [11.104, 13.207, 10.718])
+    assert np.isclose(data["occ"][0], 0.5)
+    assert data["altLoc"][0] == "A"


### PR DESCRIPTION
## Summary
- replace custom PDB parser with Bio.PDB and support mmCIF files
- expose element, altloc and header metadata from parsed structures
- test Bio.PDB parsing for mmCIF and alt-loc PDB edge cases

## Testing
- `pre-commit run --files requirements.txt src/smap_tools_python/pdb.py tests/test_struct_io.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68be12d118c48328be4d12ccd65c66d9