### PR TITLE
Improve rotation interpolation and benchmark large FFTs

### DIFF
--- a/benchmarks/benchmark_fft.py
+++ b/benchmarks/benchmark_fft.py
@@ -1,8 +1,9 @@
 """Simple benchmarks for the FFT backends.
 
-Run this module as a script to get an idea of the relative performance of the
-CPU and GPU implementations.  The benchmark performs a forward and inverse FFT
-roundtrip on a random 256x256 array.
+Run this module as a script to compare CPU and GPU implementations over a
+range of transform sizes.  By default both a modest 256×256 and a large 4096×4096
+roundtrip are performed as the crossover in efficiency between the two
+backends depends strongly on the FFT size.
 """
 
 from __future__ import annotations
@@ -15,20 +16,22 @@ from smap_tools_python import ftj, iftj
 from smap_tools_python.gpu_fft import gpu_ftj, gpu_iftj
 
 
-def benchmark(size: int = 256) -> None:
-    arr = np.random.rand(size, size)
-    t0 = time.perf_counter()
-    iftj(ftj(arr))
-    cpu_time = time.perf_counter() - t0
-    print(f"CPU roundtrip: {cpu_time:.4f}s")
-
-    if has_gpu():  # pragma: no cover - optional dependency
+def benchmark(sizes: tuple[int, ...] = (256, 4096)) -> None:
+    for size in sizes:
+        print(f"\nBenchmarking {size}x{size} FFT")
+        arr = np.random.rand(size, size)
         t0 = time.perf_counter()
-        gpu_iftj(gpu_ftj(arr))
-        gpu_time = time.perf_counter() - t0
-        print(f"GPU roundtrip: {gpu_time:.4f}s")
-    else:
-        print("GPU backend not available")
+        iftj(ftj(arr))
+        cpu_time = time.perf_counter() - t0
+        print(f"CPU roundtrip: {cpu_time:.4f}s")
+
+        if has_gpu():  # pragma: no cover - optional dependency
+            t0 = time.perf_counter()
+            gpu_iftj(gpu_ftj(arr))
+            gpu_time = time.perf_counter() - t0
+            print(f"GPU roundtrip: {gpu_time:.4f}s")
+        else:
+            print("GPU backend not available")
 
 
 if __name__ == "__main__":  # pragma: no cover - manual benchmark


### PR DESCRIPTION
## Summary
- rotate 2D and 3D arrays with bilinear/trilinear interpolation to avoid nearest-neighbour artefacts
- benchmark FFT roundtrips at both 256 and 4096 sizes to expose CPU vs GPU crossover

## Testing
- `pre-commit run --files src/smap_tools_python/rotate.py benchmarks/benchmark_fft.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68becb59b1688328823bfcf10603cdd1