### PR TITLE
Return weights from backproject

### DIFF
--- a/src/smap_tools_python/backproject.py
+++ b/src/smap_tools_python/backproject.py
@@ -4,12 +4,13 @@ from .crop_pad import extendj
 from .rotate import rotate3d_matrix
 
 
-def backproject(patches, rotations, pad_size=None):
+def backproject(patches, rotations, pad_size=None) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
     """Backproject 2-D patches into a 3-D volume.
 
     A simple real-space backprojection is performed by inserting each patch as
     a central slice of a cubic volume, rotating it according to ``rotations``
-    and summing the results.
+    and summing the results.  In addition to the summed volume, per-voxel
+    contribution counts and a placeholder array are accumulated.
 
     Parameters
     ----------
@@ -22,8 +23,12 @@ def backproject(patches, rotations, pad_size=None):
 
     Returns
     -------
-    numpy.ndarray
-        Reconstructed volume of shape ``(pad_size, pad_size, pad_size)``.
+    vol : numpy.ndarray
+        Sum of the rotated slices with shape ``(pad_size, pad_size, pad_size)``.
+    weights : numpy.ndarray
+        Count of contributions for each voxel with the same shape as ``vol``.
+    other : numpy.ndarray
+        Zero-filled volume reserved for future PSD/CTF information.
     """
 
     patches = np.asarray(patches, dtype=float)
@@ -36,6 +41,8 @@ def backproject(patches, rotations, pad_size=None):
 
     pad_size = int(pad_size or n)
     vol = np.zeros((pad_size, pad_size, pad_size), dtype=float)
+    weights = np.zeros_like(vol)
+    other = np.zeros_like(vol)
 
     rotations = np.asarray(rotations, dtype=float)
     if rotations.shape[-2:] != (3, 3):
@@ -47,12 +54,23 @@ def backproject(patches, rotations, pad_size=None):
 
     center = pad_size // 2
     for i in range(k):
-        patch = extendj(patches[:, :, i], (pad_size, pad_size), float(patches[:, :, i].mean()))
+        patch = extendj(
+            patches[:, :, i], (pad_size, pad_size), float(patches[:, :, i].mean())
+        )
+
         slice_vol = np.zeros_like(vol)
         slice_vol[:, :, center] = patch
         vol += rotate3d_matrix(slice_vol, rotations[i])
 
-    return vol / float(k)
+        mask = extendj(np.ones((n, n), dtype=float), (pad_size, pad_size), 0.0)
+        slice_mask = np.zeros_like(weights)
+        slice_mask[:, :, center] = mask
+        weights += rotate3d_matrix(slice_mask, rotations[i])
+
+        slice_other = np.zeros_like(other)
+        other += rotate3d_matrix(slice_other, rotations[i])
+
+    return vol, weights, other
 
 
 __all__ = ["backproject"]

--- a/tests/test_backproject.py
+++ b/tests/test_backproject.py
@@ -6,15 +6,13 @@ def test_backproject_identity_slice():
     patch = np.array([[1, 2], [3, 4]], float)
     patches = patch[:, :, None]
     R = np.eye(3)[None, ...]
-    vol = backproject(patches, R, pad_size=4)
-    expected = np.array(
-        [
-            [2.5, 2.5, 2.5, 2.5],
-            [2.5, 1.0, 2.0, 2.5],
-            [2.5, 3.0, 4.0, 2.5],
-            [2.5, 2.5, 2.5, 2.5],
-        ]
-    )
-    assert np.allclose(vol[:, :, 2], expected)
-    assert np.allclose(vol[:, :, :2], 0)
-    assert np.allclose(vol[:, :, 3], 0)
+    vol, weights, other = backproject(patches, R, pad_size=4)
+
+    reconstructed = np.divide(vol, weights, out=np.zeros_like(vol), where=weights > 0)
+    expected = np.zeros((4, 4))
+    expected[1:3, 1:3] = patch
+
+    assert np.allclose(reconstructed[:, :, 2], expected)
+    assert np.allclose(reconstructed[:, :, :2], 0)
+    assert np.allclose(reconstructed[:, :, 3], 0)
+    assert np.allclose(other, 0)


### PR DESCRIPTION
## Summary
- extend backproject to accumulate volume and weights and return both along with a placeholder array
- update test to use weights for normalization and ensure placeholder remains zero

## Testing
- `pytest tests/test_backproject.py`

------
https://chatgpt.com/codex/tasks/task_b_68bf0fa6b1d483289754d99052a394dd